### PR TITLE
Fix case when the group config has a element and is reincorporated to candidates

### DIFF
--- a/src/handlers/registerElementHandler.test.ts
+++ b/src/handlers/registerElementHandler.test.ts
@@ -80,4 +80,21 @@ describe('registerElementHandler', () => {
     element.id = 'element-5-0'
     expect(() => registerElement(element, 'group-5')).toThrowError(ERROR_MESSAGES.ELEMENT_NOT_FOCUSABLE(element.id))
   })
+
+  it('should keep the group element if the groups doesnt exists but config exists', () => {
+    const registerElement = registerElementHandler(state)
+
+    const group = document.createElement('div')
+    group.id = 'group-10'
+
+    state.groupsConfig.set(group.id, {
+      el: group
+    })
+
+    const element = document.createElement('button')
+    element.id = 'element-10-0'
+    registerElement(element, 'group-10')
+
+    expect(state.groups.get('group-10')?.el).toBe(group)
+  })
 })

--- a/src/handlers/registerElementHandler.ts
+++ b/src/handlers/registerElementHandler.ts
@@ -41,12 +41,13 @@ export default function registerElementHandler (state: ArrowNavigationState) {
 
     state.elements.set(element.id, focusableElement)
     const existentGroup = state.groups.get(group)
+    const existentGroupConfig = state.groupsConfig.get(group)
 
     if (!existentGroup) {
       const elementsMap = new Map().set(element.id, focusableElement)
       state.groups.set(group, {
         elements: elementsMap,
-        el: null as unknown as HTMLElement
+        el: existentGroupConfig?.el || null as unknown as HTMLElement
       })
     } else {
       existentGroup.elements.set(element.id, focusableElement)


### PR DESCRIPTION
Fix case when all the elements are remounted and the group is reincorporated to eligibles, taking the element from persisted config.