### PR TITLE
Extend ArrowNavigationApi with getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,90 @@ const api = getArrowNavigation()
 api.destroy()
 ```
 
+### getCurrentGroups
+
+Get the current groups ids (focusables).
+
+```typescript
+const api = getArrowNavigation()
+
+const container = document.createElement('div')
+const container2 = document.createElement('div')
+
+// Is important to keep a unique id for each group and his elements
+container.id = 'group-0'
+container2.id = 'group-1'
+
+api.registerGroup(container)
+api.registerGroup(container2)
+
+const currentGroups = api.getCurrentGroups() // Set { 'group-0', 'group-1' }
+```
+
+### getGroupElements
+
+Get a Set of elements ids of a group.
+
+```typescript
+const api = getArrowNavigation()
+
+const container = document.createElement('div')
+const element = document.createElement('button')
+const element2 = document.createElement('button')
+
+// Is important to keep a unique id for each group and his elements
+container.id = 'group-0'
+element.id = 'element-0-0'
+element2.id = 'element-0-1'
+
+api.registerGroup(container)
+api.registerElement(element, 'group-0')
+api.registerElement(element2, 'group-0')
+
+const groupElements = api.getGroupElements('group-0') // Set { 'element-0-0', 'element-0-1' }
+```
+
+### getGroupConfig
+
+Get the configuration of a group.
+
+```typescript
+const api = getArrowNavigation()
+
+const container = document.createElement('div')
+
+// Is important to keep a unique id for each group and his elements
+container.id = 'group-0'
+
+api.registerGroup(container)
+
+const groupConfig = api.getGroupConfig('group-0') // { viewportSafe: true, threshold: 0, keepFocus: false }
+```
+
+### getRegisteredElements
+
+Get a Set with all registered elements ids.
+
+```typescript
+const api = getArrowNavigation()
+
+const container = document.createElement('div')
+const element = document.createElement('button')
+const element2 = document.createElement('button')
+
+// Is important to keep a unique id for each group and his elements
+
+container.id = 'group-0'
+element.id = 'element-0-0'
+element2.id = 'element-0-1'
+
+api.registerGroup(container)
+api.registerElement(element, 'group-0')
+api.registerElement(element2, 'group-0')
+
+const registeredElements = api.getRegisteredElements() // Set { 'element-0-0', 'element-0-1' }
+```
+
 # Using with CDN
 
 You can use the module with a CDN. The module is available in the following URL:
@@ -225,7 +309,7 @@ You can use the module with a CDN. The module is available in the following URL:
 `https://cdn.jsdelivr.net/npm/@arrow-navigation/core@<version>/dist/dist.js`
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@arrow-navigation/core@1.0.1/dist/dist.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@arrow-navigation/core/dist/dist.js"></script>
 <script>
   window.arrowNavigation.init()
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![codecov](https://codecov.io/gh/borisbelmar/arrow-navigation/branch/main/graph/badge.svg?token=6EEWATKTFX)](https://codecov.io/gh/borisbelmar/arrow-navigation)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![install size](https://packagephobia.com/badge?p=@arrow-navigation/core@1.0.1)](https://packagephobia.com/result?p=@arrow-navigation/core@1.0.1)
+[![install size](https://packagephobia.com/badge?p=@arrow-navigation/core@1.1.0)](https://packagephobia.com/result?p=@arrow-navigation/core@1.1.0)
 
 Light (7.2kb) and zero-dependency module to navigate through elements using the arrow keys written in Typescript.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrow-navigation/core",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Zero-dependency library to navigate through UI elements using the keyboard arrow keys built with Typescript",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/arrowNavigation.test.ts
+++ b/src/arrowNavigation.test.ts
@@ -64,6 +64,17 @@ describe('arrowNavigation', () => {
     expect(state.groups.get('group-0')?.elements.get('element-0-2')?.el.focus).toHaveBeenCalled()
   })
 
+  it('should not forceNavigate if debug is disabled', () => {
+    initArrowNavigation()
+    const navigationApi = getArrowNavigation()
+    const state = getViewNavigationStateMock()
+    navigationApi._setState(state)
+
+    navigationApi._forceNavigate('ArrowDown')
+
+    expect(state.groups.get('group-0')?.elements.get('element-0-1')?.el.focus).not.toHaveBeenCalled()
+  })
+
   it('should return the focused element', () => {
     initArrowNavigation({ debug: true })
     const navigationApi = getArrowNavigation()
@@ -82,5 +93,80 @@ describe('arrowNavigation', () => {
     navigationApi._setState(state)
 
     expect(navigationApi._getState()).toEqual({ ...state, debug: true })
+  })
+
+  it('should return the state in non debug mode', () => {
+    initArrowNavigation()
+    const navigationApi = getArrowNavigation()
+
+    expect(navigationApi._getState()).toBeNull()
+  })
+
+  it('should return all the elements as a set', () => {
+    initArrowNavigation({ debug: true })
+    const state = getViewNavigationStateMock()
+    const navigationApi = getArrowNavigation()
+    navigationApi._setState(state)
+
+    expect(navigationApi.getRegisteredElements()).toEqual(new Set(state.elements.keys()))
+  })
+
+  it('should return all the elements in a group as set', () => {
+    initArrowNavigation({ debug: true })
+    const state = getViewNavigationStateMock()
+    const navigationApi = getArrowNavigation()
+    navigationApi._setState(state)
+
+    expect(navigationApi.getGroupElements('group-0')).toEqual(new Set(state.groups.get('group-0')?.elements.keys() || []))
+  })
+
+  it('should return all the groups as a set', () => {
+    initArrowNavigation({ debug: true })
+    const state = getViewNavigationStateMock()
+    const navigationApi = getArrowNavigation()
+    navigationApi._setState(state)
+
+    expect(navigationApi.getCurrentGroups()).toEqual(new Set(state.groups.keys()))
+  })
+
+  it('should return the focused group', () => {
+    initArrowNavigation({ debug: true })
+    const state = getViewNavigationStateMock()
+    const navigationApi = getArrowNavigation()
+    navigationApi._setState(state)
+
+    expect(navigationApi.getFocusedGroup()).toBe('group-0')
+  })
+
+  it('should return the group config', () => {
+    initArrowNavigation({ debug: true })
+    const state = getViewNavigationStateMock()
+    const navigationApi = getArrowNavigation()
+    navigationApi._setState(state)
+
+    expect(navigationApi.getGroupConfig('group-0')).toEqual(state.groupsConfig.get('group-0'))
+  })
+
+  it('should not set a new state if debug is false', () => {
+    initArrowNavigation()
+    const navigationApi = getArrowNavigation()
+    const state = getViewNavigationStateMock()
+
+    navigationApi._setState(state)
+    expect(navigationApi.getFocusedElement()).toBeNull()
+  })
+
+  it('should return an empty set if the group does not exist', () => {
+    initArrowNavigation({ debug: true })
+    const navigationApi = getArrowNavigation()
+
+    expect(navigationApi.getGroupElements('group-0')).toEqual(new Set())
+  })
+
+  it('should return undefined group if currentElement is not set', () => {
+    initArrowNavigation({ debug: true })
+    const navigationApi = getArrowNavigation()
+
+    expect(navigationApi.getFocusedGroup()).toBeUndefined()
   })
 })

--- a/src/arrowNavigation.ts
+++ b/src/arrowNavigation.ts
@@ -72,6 +72,21 @@ export function initArrowNavigation ({
       window.removeEventListener('keydown', onKeyPress)
       arrowNavigation = null
     },
+    getCurrentGroups () {
+      return new Set(state.groups.keys())
+    },
+    getGroupElements (group: string) {
+      return new Set(state.groups.get(group)?.elements.keys() || [])
+    },
+    getGroupConfig (group: string) {
+      return state.groupsConfig.get(group)
+    },
+    getRegisteredElements () {
+      return new Set(state.elements.keys())
+    },
+    getFocusedGroup () {
+      return state.currentElement?.group
+    },
     _forceNavigate (key) {
       if (!state.debug) return
       onKeyPress({

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -67,6 +67,11 @@ export type ArrowNavigationInstance = {
   registerElement: (element: HTMLElement, group: string, options?: Omit<FocusableElement, 'el' | 'group'>) => void
   unregisterElement: (element: string | HTMLElement) => void
   destroy: () => void
+  getCurrentGroups: () => Set<string>
+  getGroupElements: (group: string) => Set<string>
+  getGroupConfig: (group: string) => FocusableGroupConfig | undefined
+  getRegisteredElements: () => Set<string>
+  getFocusedGroup: () => string | undefined
   /**
    * @deprecated
    * @returns The current state of the arrow navigation instance.


### PR DESCRIPTION
Add new methods to the arrow navigation api:

```typescript
getCurrentGroups: () => Set<string>
getGroupElements: (group: string) => Set<string>
getGroupConfig: (group: string) => FocusableGroupConfig | undefined
getRegisteredElements: () => Set<string>
getFocusedGroup: () => string | undefined
```