### PR TITLE
Add prev and next elements and group to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ registerGroup(container, {
   saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
   viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true
   threshold: 2, // The threshold in pixels to consider an element eligible to be focused. The default value is 0
-  onFocus: (group) => { console.log(`focused ${group.el.id}`) }, // Callback when the group is focused
-  onBlur: (group) => { console.log(`blurred ${group.el.id}`) },
+  onFocus: ({ current, prev, direction }) => { console.log(`focused ${group.el.id}`) }, // Callback when the group is focused. The prev group is the group that was focused before the current group.
+  onBlur: ({ current, next, direction }) => { console.log(`blurred ${group.el.id}`) }, // Callback when the group is blurred. The next group is the group that will be focused when the focus leave the current group.
   keepFocus: true // If true, the focus will not leave the group when the user press the arrow keys. The default value is false. This option is usefull for modals or other elements that need to keep the focus inside.
 })
 ```
@@ -140,8 +140,8 @@ api.registerElement(element, 'group-1', {
     'up': null, // If press up, no elements will be focused
     'left': undefined // undefined will keep the default behavior
   },
-  onFocus: (element) => console.log(`focused ${element.el.id}`), // Callback when the element is focused
-  onBlur: (element) => console.log(`blurred ${element.el.id}`) // Callback when the element is blurred
+  onFocus: ({ current, prev, direction }) => console.log(`focused ${element.el.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
+  onBlur: ({ current, next, direction }) => console.log(`blurred ${element.el.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
 })
 ```
 
@@ -378,19 +378,19 @@ This event is triggered when the current group is changed. The event will receiv
 
 ### element:focus
 
-This event is triggered when an element is focused. The event will receive the element as first parameter and direction as second parameter.
+This event is triggered when an element is focused. The event will receive `(currentElement, direction, prevElement)`.
 
 ### element:blur
 
-This event is triggered when an element is blurred. The event will receive the element as first parameter and direction as second parameter.
+This event is triggered when an element is blurred. The event will receive `(currentElement, direction, nextElement)`.
 
 ### group:focus
 
-This event is triggered when a group is focused. The event will receive the group as first parameter and direction as second parameter.
+This event is triggered when a group is focused. The event will receive `(currentGroup, direction, prevGroup)`.
 
 ### group:blur
 
-This event is triggered when a group is blurred. The event will receive the group as first parameter and direction as second parameter.
+This event is triggered when a group is blurred. The event will receive `(currentGroup, direction, nextGroup)`.
 
 ### groups:change
 

--- a/src/arrowNavigation.ts
+++ b/src/arrowNavigation.ts
@@ -64,7 +64,7 @@ export function initArrowNavigation ({
     getFocusedElement: () => state.currentElement,
     setFocusElement: setFocusHandler(state, changeFocusElementHandler),
     registerGroup: registerGroupHandler(state, emitter.emit),
-    registerElement: registerElementHandler(state, emitter.emit),
+    registerElement: registerElementHandler(state, changeFocusElementHandler, emitter.emit),
     unregisterElement: unregisterElementHandler(state, changeFocusElementHandler, emitter.emit),
     destroy () {
       window.removeEventListener('keydown', onKeyPress)

--- a/src/handlers/changeFocusEventHandler.test.ts
+++ b/src/handlers/changeFocusEventHandler.test.ts
@@ -54,10 +54,10 @@ describe('changeFocusEventHandler', () => {
       emit: emitter.emit
     })
 
-    expect(events.onElementFocus).toHaveBeenCalledWith(nextElement, 'down')
-    expect(events.onElementBlur).toHaveBeenCalledWith(state.currentElement as FocusableElement, 'down')
-    expect(events.onGroupBlur).toHaveBeenCalledWith(state.groupsConfig.get('group-0'), 'down')
-    expect(events.onGroupFocus).toHaveBeenCalledWith(state.groupsConfig.get('group-1'), 'down')
+    expect(events.onElementFocus).toHaveBeenCalledWith(nextElement, 'down', prevElement)
+    expect(events.onElementBlur).toHaveBeenCalledWith(state.currentElement as FocusableElement, 'down', nextElement)
+    expect(events.onGroupBlur).toHaveBeenCalledWith(state.groupsConfig.get('group-0'), 'down', state.groupsConfig.get('group-1'))
+    expect(events.onGroupFocus).toHaveBeenCalledWith(state.groupsConfig.get('group-1'), 'down', state.groupsConfig.get('group-0'))
   })
 
   it('should call onFocus and onBlur on group and element', () => {
@@ -85,14 +85,30 @@ describe('changeFocusEventHandler', () => {
       emit: emitter.emit
     })
 
-    expect(currentGroupConfig.onBlur).toHaveBeenCalled()
+    expect(currentGroupConfig.onBlur).toHaveBeenCalledWith({
+      direction: 'down',
+      current: currentGroupConfig,
+      next: nextGroupConfig
+    })
     expect(currentGroupConfig.onFocus).not.toHaveBeenCalled()
-    expect(prevElement.onBlur).toHaveBeenCalled()
+    expect(prevElement.onBlur).toHaveBeenCalledWith({
+      direction: 'down',
+      current: prevElement,
+      next: nextElement
+    })
     expect(prevElement.onFocus).not.toHaveBeenCalled()
 
-    expect(nextGroupConfig.onFocus).toHaveBeenCalled()
+    expect(nextGroupConfig.onFocus).toHaveBeenCalledWith({
+      direction: 'down',
+      current: nextGroupConfig,
+      prev: currentGroupConfig
+    })
     expect(nextGroupConfig.onBlur).not.toHaveBeenCalled()
-    expect(nextElement.onFocus).toHaveBeenCalled()
+    expect(nextElement.onFocus).toHaveBeenCalledWith({
+      direction: 'down',
+      current: nextElement,
+      prev: prevElement
+    })
     expect(nextElement.onBlur).not.toHaveBeenCalled()
   })
 
@@ -124,9 +140,9 @@ describe('changeFocusEventHandler', () => {
       emit: emitter.emit
     })
 
-    expect(events.onElementFocus).toHaveBeenCalledWith(nextElement, 'down')
+    expect(events.onElementFocus).toHaveBeenCalledWith(nextElement, 'down', null)
     expect(events.onElementBlur).not.toHaveBeenCalled()
     expect(events.onGroupBlur).not.toHaveBeenCalled()
-    expect(events.onGroupFocus).toHaveBeenCalledWith(state.groupsConfig.get('group-1'), 'down')
+    expect(events.onGroupFocus).toHaveBeenCalledWith(state.groupsConfig.get('group-1'), 'down', undefined)
   })
 })

--- a/src/handlers/changeFocusEventHandler.ts
+++ b/src/handlers/changeFocusEventHandler.ts
@@ -18,21 +18,37 @@ export default function changeFocusEventHandler ({
     const nextGroup = state.groupsConfig.get(nextElement.group as string)
 
     if (prevGroup) {
-      prevGroup.onBlur?.()
-      emit(EVENTS.GROUP_BLUR, prevGroup, direction)
+      prevGroup.onBlur?.({
+        current: prevGroup,
+        next: nextGroup,
+        direction
+      })
+      emit(EVENTS.GROUP_BLUR, prevGroup, direction, nextGroup)
     }
 
     if (nextGroup) {
-      nextGroup.onFocus?.()
-      emit(EVENTS.GROUP_FOCUS, nextGroup, direction)
-      emit(EVENTS.CURRENT_GROUP_CHANGE, nextGroup, direction)
+      nextGroup.onFocus?.({
+        current: nextGroup,
+        prev: prevGroup,
+        direction
+      })
+      emit(EVENTS.GROUP_FOCUS, nextGroup, direction, prevGroup)
+      emit(EVENTS.CURRENT_GROUP_CHANGE, nextGroup, direction, prevGroup)
     }
   }
   if (prevElement) {
-    prevElement.onBlur?.()
-    emit(EVENTS.ELEMENT_BLUR, prevElement, direction)
+    prevElement.onBlur?.({
+      current: prevElement,
+      next: nextElement,
+      direction
+    })
+    emit(EVENTS.ELEMENT_BLUR, prevElement, direction, nextElement)
   }
-  nextElement.onFocus?.()
-  emit(EVENTS.ELEMENT_FOCUS, nextElement, direction)
-  emit(EVENTS.CURRENT_ELEMENT_CHANGE, nextElement, direction)
+  nextElement.onFocus?.({
+    current: nextElement,
+    prev: prevElement,
+    direction
+  })
+  emit(EVENTS.ELEMENT_FOCUS, nextElement, direction, prevElement)
+  emit(EVENTS.CURRENT_ELEMENT_CHANGE, nextElement, direction, prevElement)
 }

--- a/src/handlers/registerElementHandler.test.ts
+++ b/src/handlers/registerElementHandler.test.ts
@@ -6,14 +6,16 @@ import registerElementHandler, { ERROR_MESSAGES } from './registerElementHandler
 describe('registerElementHandler', () => {
   let state: ArrowNavigationState
   let emitter: EventEmitter
+  let onChangeElement: () => void
 
   beforeEach(() => {
     state = getViewNavigationStateMock()
     emitter = createEventEmitter()
+    onChangeElement = jest.fn()
   })
 
   it('should register the element on a new group', () => {
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const element = document.createElement('button')
     element.id = 'element-5-0'
@@ -24,7 +26,7 @@ describe('registerElementHandler', () => {
   })
 
   it('should register the element on an existing group', () => {
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
     const groupId = 'group-0'
     const group = state.groups.get(groupId) as FocusableGroup
     const groupTotalElements = group.elements.size
@@ -39,14 +41,14 @@ describe('registerElementHandler', () => {
   })
 
   it('should throw an error if the element id is not defined', () => {
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const element = document.createElement('button')
     expect(() => registerElement(element, 'group-1')).toThrowError(ERROR_MESSAGES.ELEMENT_ID_REQUIRED)
   })
 
   it('should throw an error if the group id is not defined', () => {
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const element = document.createElement('button')
     element.id = 'element-1-0'
@@ -55,7 +57,7 @@ describe('registerElementHandler', () => {
 
   it('should log a warn message if element id is already registered and not register the element', () => {
     global.console.warn = jest.fn()
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const element = document.createElement('button')
     element.id = 'element-0-0'
@@ -68,17 +70,17 @@ describe('registerElementHandler', () => {
 
   it('should set the element as the current element if current is null', () => {
     state.currentElement = null
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const element = document.createElement('button')
     element.id = 'element-5-0'
     registerElement(element, 'group-5')
 
-    expect(state.currentElement).toBe(state.elements.get(element.id))
+    expect(onChangeElement).toHaveBeenCalledWith({ el: element, group: 'group-5' })
   })
 
   it('should throw an error if the element is not focusable', () => {
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const element = document.createElement('div')
     element.id = 'element-5-0'
@@ -86,7 +88,7 @@ describe('registerElementHandler', () => {
   })
 
   it('should keep the group element if the groups doesnt exists but config exists', () => {
-    const registerElement = registerElementHandler(state, emitter.emit)
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
 
     const group = document.createElement('div')
     group.id = 'group-10'

--- a/src/handlers/registerElementHandler.ts
+++ b/src/handlers/registerElementHandler.ts
@@ -1,6 +1,6 @@
 import EVENTS from '@/config/events'
-import type { ArrowNavigationState, FocusableElementOptions } from '@/types'
-import { EventEmitter } from '@/utils/createEventEmitter'
+import type { ArrowNavigationState, FocusableElement, FocusableElementOptions } from '@/types'
+import type { EventEmitter } from '@/utils/createEventEmitter'
 import isElementDisabled from './utils/isElementDisabled'
 import isFocusableElement from './utils/isFocusableElement'
 
@@ -13,6 +13,7 @@ export const ERROR_MESSAGES = {
 
 export default function registerElementHandler (
   state: ArrowNavigationState,
+  onChangeCurrentElement: (element: FocusableElement) => void,
   emit: EventEmitter['emit']
 ) {
   return (
@@ -61,11 +62,7 @@ export default function registerElementHandler (
     }
 
     if (!state.currentElement && !isElementDisabled(focusableElement.el)) {
-      // eslint-disable-next-line no-param-reassign
-      state.currentElement = focusableElement
-      element.focus()
-      emit(EVENTS.CURRENT_ELEMENT_CHANGE, focusableElement)
-      emit(EVENTS.CURRENT_GROUP_CHANGE, state.groupsConfig.get(group))
+      onChangeCurrentElement(focusableElement)
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,12 +10,25 @@ export type ElementByDirection = {
   [key in Direction]?: string | null
 }
 
+type EventResult<T> = {
+  current: T | undefined | null
+  direction: Direction | undefined | null
+}
+
+type FocusEventResult<T> = EventResult<T> & {
+  prev: T | undefined | null
+}
+
+type BlurEventResult<T> = EventResult<T> & {
+  next: T | undefined | null
+}
+
 export type FocusableElement = {
   el: HTMLElement
   group: string
   nextElementByDirection?: ElementByDirection
-  onFocus?: () => void
-  onBlur?: () => void
+  onFocus?: (result: FocusEventResult<FocusableElement>) => void
+  onBlur?: (result: BlurEventResult<FocusableElement>) => void
 }
 
 export type FocusableElementOptions = Omit<FocusableElement, 'el' | 'group'>
@@ -32,8 +45,8 @@ export type FocusableGroupConfig = {
   saveLast?: boolean
   viewportSafe?: boolean
   threshold?: number
-  onFocus?: () => void
-  onBlur?: () => void
+  onFocus?: (result: FocusEventResult<FocusableGroupConfig>) => void
+  onBlur?: (result: BlurEventResult<FocusableGroupConfig>) => void
   keepFocus?: boolean
 }
 


### PR DESCRIPTION
Improve events, adding more information about it.

## On element config:

```typescript
api.registerElement(element, 'group-1', {
  nextElementByDirection: { // This will set the next element manually
    'down': 'element-0-1', // The next element when the user press the down arrow key
    'up': null, // If press up, no elements will be focused
    'left': undefined // undefined will keep the default behavior
  },
  onFocus: ({ current, prev, direction }) => console.log(`focused ${current.el.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
  onBlur: ({ current, next, direction }) => console.log(`blurred ${current.el.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
})
```

## On group config:

```typescript
api.registerGroup(container, {
  firstElement: 'element-0-0', // The first element to be focused when the focus enter the group
  nextGroupByDirection: {
    'down': 'group-1', // The next group when the user press the down arrow key
    'up': null, // If press up, no groups will be focused
    'left': undefined // undefined will keep the default behavior
  },
  saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
  viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true
  threshold: 2, // The threshold in pixels to consider an element eligible to be focused. The default value is 0
  onFocus: ({ current, prev, direction }) => { console.log(`focused ${current.el.id}`) }, // Callback when the group is focused. The prev group is the group that was focused before the current group.
  onBlur: ({ current, next, direction }) => { console.log(`blurred ${current.el.id}`) }, // Callback when the group is blurred. The next group is the group that will be focused when the focus leave the current group.
  keepFocus: true // If true, the focus will not leave the group when the user press the arrow keys. The default value is false. This option is usefull for modals or other elements that need to keep the focus inside.
})
```

## On Events:

### element:focus

This event is triggered when an element is focused. The event will receive `(currentElement, direction, prevElement)`.

### element:blur

This event is triggered when an element is blurred. The event will receive `(currentElement, direction, nextElement)`.

### group:focus

This event is triggered when a group is focused. The event will receive `(currentGroup, direction, prevGroup)`.

### group:blur

This event is triggered when a group is blurred. The event will receive `(currentGroup, direction, nextGroup)`.
