### PR TITLE
Add nextByDirection and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ api.registerGroup(container, {
   saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
   viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true
   threshold: 2, // The threshold in pixels to consider an element eligible to be focused. The default value is 0
-  onFocus: ({ current, prev, direction }) => { console.log(`focused ${current.el.id}`) }, // Callback when the group is focused. The prev group is the group that was focused before the current group.
-  onBlur: ({ current, next, direction }) => { console.log(`blurred ${current.el.id}`) }, // Callback when the group is blurred. The next group is the group that will be focused when the focus leave the current group.
+  onFocus: ({ current, prev, direction }) => { console.log(`focused ${current.id}`) }, // Callback when the group is focused. The prev group is the group that was focused before the current group.
+  onBlur: ({ current, next, direction }) => { console.log(`blurred ${current.id}`) }, // Callback when the group is blurred. The next group is the group that will be focused when the focus leave the current group.
   keepFocus: true // If true, the focus will not leave the group when the user press the arrow keys. The default value is false. This option is usefull for modals or other elements that need to keep the focus inside.
 })
 ```
@@ -135,13 +135,14 @@ const element = document.createElement('button')
 element.id = 'element-0-0'
 
 api.registerElement(element, 'group-1', {
-  nextElementByDirection: { // This will set the next element manually
+  nextByDirection: { // This will set the next element manually
     'down': 'element-0-1', // The next element when the user press the down arrow key
+    'right': { id: 'group-1', kind: 'group' }, // The next group when the user press the right arrow key
     'up': null, // If press up, no elements will be focused
     'left': undefined // undefined will keep the default behavior
   },
-  onFocus: ({ current, prev, direction }) => console.log(`focused ${current.el.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
-  onBlur: ({ current, next, direction }) => console.log(`blurred ${current.el.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
+  onFocus: ({ current, prev, direction }) => console.log(`focused ${current.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
+  onBlur: ({ current, next, direction }) => console.log(`blurred ${current.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
 })
 ```
 

--- a/src/__mocks__/viewNavigationState.mock.ts
+++ b/src/__mocks__/viewNavigationState.mock.ts
@@ -6,10 +6,11 @@ export default function getViewNavigationStateMock (): ArrowNavigationState {
 
   const getSquareElement = (id: string, group: string, x: number, y: number) => {
     const focusableElement = {
+      id,
       el: getHtmlElementMock({ id, x, y, width: 10, height: 10 }),
       group
     }
-    elements.set(focusableElement.el.id, focusableElement)
+    elements.set(focusableElement.id, focusableElement)
     return focusableElement
   }
 
@@ -17,56 +18,66 @@ export default function getViewNavigationStateMock (): ArrowNavigationState {
   const groupsConfig = new Map<string, FocusableGroupConfig>()
 
   const group1: FocusableGroup = {
+    id: 'group-0',
     el: getHtmlElementMock({ id: 'group-0', x: 0, y: 0, width: 16, height: 52 }),
-    elements: new Map()
-  }
-  group1.elements.set('element-0-0', getSquareElement('element-0-0', 'group-0', 3, 3))
-  group1.elements.set('element-0-1', getSquareElement('element-0-1', 'group-0', 3, 15))
-  group1.elements.set('element-0-2', getSquareElement('element-0-2', 'group-0', 3, 27))
-  group1.elements.set('element-0-3', getSquareElement('element-0-3', 'group-0', 3, 39))
-  groups.set(group1.el.id, group1)
-  groupsConfig.set(group1.el.id, { el: group1.el })
+    elements: new Set()
+  };
+  [0, 1, 2, 3].forEach(i => {
+    const id = `element-0-${i}`
+    getSquareElement(id, 'group-0', 3, 3 + (12 * i))
+    group1.elements.add(id)
+  })
+  groups.set(group1.id, group1)
+  groupsConfig.set(group1.id, { el: group1.el, id: group1.id })
 
   const group2: FocusableGroup = {
+    id: 'group-1',
     el: getHtmlElementMock({ id: 'group-1', x: 16, y: 0, width: 52, height: 16 }),
-    elements: new Map()
-  }
-  group2.elements.set('element-1-0', getSquareElement('element-1-0', 'group-1', 19, 3))
-  group2.elements.set('element-1-1', getSquareElement('element-1-1', 'group-1', 31, 3))
-  group2.elements.set('element-1-2', getSquareElement('element-1-2', 'group-1', 43, 3))
-  group2.elements.set('element-1-3', getSquareElement('element-1-3', 'group-1', 55, 3))
-  groups.set(group2.el.id, group2)
-  groupsConfig.set(group2.el.id, { el: group2.el })
+    elements: new Set()
+  };
+  [0, 1, 2, 3].forEach(i => {
+    const id = `element-1-${i}`
+    getSquareElement(id, 'group-1', 19 + (12 * i), 3)
+    group2.elements.add(id)
+  })
+  groups.set(group2.id, group2)
+  groupsConfig.set(group2.id, { el: group2.el, id: group2.id })
 
   const group3: FocusableGroup = {
+    id: 'group-2',
     el: getHtmlElementMock({ id: 'group-2', x: 16, y: 18, width: 52, height: 16 }),
-    elements: new Map()
-  }
-  group3.elements.set('element-2-0', getSquareElement('element-2-0', 'group-2', 19, 21))
-  group3.elements.set('element-2-1', getSquareElement('element-2-1', 'group-2', 31, 21))
-  group3.elements.set('element-2-2', getSquareElement('element-2-2', 'group-2', 43, 21))
-  group3.elements.set('element-2-3', getSquareElement('element-2-3', 'group-2', 55, 21))
-  groups.set(group3.el.id, group3)
-  groupsConfig.set(group3.el.id, { el: group3.el })
+    elements: new Set()
+  };
+  [0, 1, 2, 3].forEach(i => {
+    const id = `element-2-${i}`
+    getSquareElement(id, 'group-2', 19 + (12 * i), 21)
+    group3.elements.add(id)
+  })
+  groups.set(group3.id, group3)
+  groupsConfig.set(group3.id, { el: group3.el, id: group3.id })
 
   const group4: FocusableGroup = {
+    id: 'group-3',
     el: getHtmlElementMock({ id: 'group-3', x: 16, y: 36, width: 52, height: 16 }),
-    elements: new Map()
-  }
-  group4.elements.set('element-3-0', getSquareElement('element-3-0', 'group-3', 19, 39))
-  group4.elements.set('element-3-1', getSquareElement('element-3-1', 'group-3', 31, 39))
-  group4.elements.set('element-3-2', getSquareElement('element-3-2', 'group-3', 43, 39))
-  group4.elements.set('element-3-3', getSquareElement('element-3-3', 'group-3', 55, 39))
-  groups.set(group4.el.id, group4)
-  groupsConfig.set(group4.el.id, { el: group4.el })
+    elements: new Set()
+  };
+  [0, 1, 2, 3].forEach(i => {
+    const id = `element-3-${i}`
+    getSquareElement(id, 'group-3', 19 + (12 * i), 39)
+    group4.elements.add(id)
+  })
+  groups.set(group4.id, group4)
+  groupsConfig.set(group4.id, { el: group4.el, id: group4.id })
 
   const group5: FocusableGroup = {
+    id: 'group-4',
     el: getHtmlElementMock({ id: 'group-4', x: 0, y: 52, width: 16, height: 16 }),
-    elements: new Map()
+    elements: new Set()
   }
-  group5.elements.set('element-4-0', getSquareElement('element-4-0', 'group-4', 3, 55))
-  groups.set(group5.el.id, group5)
-  groupsConfig.set(group5.el.id, { el: group5.el })
+  getSquareElement('element-4-0', 'group-4', 3, 55)
+  group5.elements.add('element-4-0')
+  groups.set(group5.id, group5)
+  groupsConfig.set(group5.id, { el: group5.el, id: group5.id })
   return {
     currentElement: 'element-0-0',
     elements,

--- a/src/arrowNavigation.test.ts
+++ b/src/arrowNavigation.test.ts
@@ -59,11 +59,11 @@ describe('arrowNavigation', () => {
 
     navigationApi._forceNavigate('ArrowDown')
 
-    expect(state.groups.get('group-0')?.elements.get('element-0-1')?.el.focus).toHaveBeenCalled()
+    expect(state.elements.get('element-0-1')?.el.focus).toHaveBeenCalled()
 
     navigationApi._forceNavigate('ArrowDown')
 
-    expect(state.groups.get('group-0')?.elements.get('element-0-2')?.el.focus).toHaveBeenCalled()
+    expect(state.elements.get('element-0-2')?.el.focus).toHaveBeenCalled()
   })
 
   it('should not forceNavigate if debug is disabled', () => {
@@ -74,7 +74,7 @@ describe('arrowNavigation', () => {
 
     navigationApi._forceNavigate('ArrowDown')
 
-    expect(state.groups.get('group-0')?.elements.get('element-0-1')?.el.focus).not.toHaveBeenCalled()
+    expect(state.elements.get('element-0-1')?.el.focus).not.toHaveBeenCalled()
   })
 
   it('should return the focused element', () => {
@@ -217,6 +217,6 @@ describe('arrowNavigation', () => {
     navigationApi._forceNavigate('ArrowDown')
 
     expect(listener).toHaveBeenCalledWith('last')
-    expect(navigationApi.getFocusedElement()?.el.id).toBe('element-0-3')
+    expect(navigationApi.getFocusedElement()?.id).toBe('element-0-3')
   })
 })

--- a/src/arrowNavigation.ts
+++ b/src/arrowNavigation.ts
@@ -80,7 +80,7 @@ export function initArrowNavigation ({
       return new Set(state.groups.keys())
     },
     getGroupElements (group: string) {
-      return new Set(state.groups.get(group)?.elements.keys() || [])
+      return new Set(state.groups.get(group)?.elements.keys())
     },
     getGroupConfig (group: string) {
       return state.groupsConfig.get(group)

--- a/src/arrowNavigation.ts
+++ b/src/arrowNavigation.ts
@@ -37,7 +37,7 @@ export function initArrowNavigation ({
 
   const changeFocusElementHandler = (nextElement: FocusableElement, direction?: Direction) => {
     const prevElement = getCurrentElement(state) as FocusableElement
-    state.currentElement = nextElement.el.id
+    state.currentElement = nextElement.id
     nextElement.el.focus()
     changeFocusEventHandler({
       nextElement,

--- a/src/handlers/changeFocusEventHandler.test.ts
+++ b/src/handlers/changeFocusEventHandler.test.ts
@@ -1,7 +1,7 @@
 import EVENTS from '@/config/events'
 import createEventEmitter, { EventEmitter } from '@/utils/createEventEmitter'
 import getCurrentElement from '@/utils/getCurrentElement'
-import { ArrowNavigationState, FocusableElement, FocusableGroup, FocusableGroupConfig } from '../types'
+import { ArrowNavigationState, FocusableElement, FocusableGroupConfig } from '../types'
 import getViewNavigationStateMock from '../__mocks__/viewNavigationState.mock'
 import changeFocusEventHandler from './changeFocusEventHandler'
 
@@ -32,8 +32,8 @@ describe('changeFocusEventHandler', () => {
   })
 
   it('should call onElementFocus, onElementBlur, onGroupBlur and onGroupFocus correctly', () => {
-    const prevElement = state.groups.get('group-0')?.elements.get('element-0-0') as FocusableElement
-    const nextElement = state.groups.get('group-1')?.elements.get('element-1-0') as FocusableElement
+    const prevElement = state.elements.get('element-0-0') as FocusableElement
+    const nextElement = state.elements.get('element-1-0') as FocusableElement
 
     const events = {
       onElementFocus: jest.fn(),
@@ -62,17 +62,15 @@ describe('changeFocusEventHandler', () => {
   })
 
   it('should call onFocus and onBlur on group and element', () => {
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
     const currentGroupConfig = state.groupsConfig.get('group-0') as FocusableGroupConfig
-    const prevElement = currentGroup.elements.get('element-0-0') as FocusableElement
+    const prevElement = state.elements.get('element-0-0') as FocusableElement
     currentGroupConfig.onFocus = jest.fn()
     currentGroupConfig.onBlur = jest.fn()
     prevElement.onFocus = jest.fn()
     prevElement.onBlur = jest.fn()
 
-    const nextGroup = state.groups.get('group-1') as FocusableGroup
     const nextGroupConfig = state.groupsConfig.get('group-1') as FocusableGroupConfig
-    const nextElement = nextGroup.elements.get('element-1-0') as FocusableElement
+    const nextElement = state.elements.get('element-1-0') as FocusableElement
     nextGroupConfig.onFocus = jest.fn()
     nextGroupConfig.onBlur = jest.fn()
     nextElement.onFocus = jest.fn()
@@ -115,7 +113,7 @@ describe('changeFocusEventHandler', () => {
 
   it('should not call onBlur if no prevGroup', () => {
     const prevElement = null
-    const nextElement = state.groups.get('group-1')?.elements.get('element-1-0') as FocusableElement
+    const nextElement = state.elements.get('element-1-0') as FocusableElement
 
     const events = {
       onElementFocus: jest.fn(),
@@ -149,8 +147,8 @@ describe('changeFocusEventHandler', () => {
 
   it('should save the last element of the group if saveLast is true', () => {
     const currentGroupConfig = state.groupsConfig.get('group-0') as FocusableGroupConfig
-    const nextElement = state.groups.get('group-1')?.elements.get('element-1-0') as FocusableElement
-    const prevElement = state.groups.get('group-0')?.elements.get('element-0-0') as FocusableElement
+    const nextElement = state.elements.get('element-1-0') as FocusableElement
+    const prevElement = state.elements.get('element-0-0') as FocusableElement
     currentGroupConfig.saveLast = true
     currentGroupConfig.lastElement = undefined
 

--- a/src/handlers/changeFocusEventHandler.ts
+++ b/src/handlers/changeFocusEventHandler.ts
@@ -19,9 +19,9 @@ export default function changeFocusEventHandler ({
 
     if (prevGroup) {
       if (prevGroup.saveLast) {
-        state.groupsConfig.set(prevGroup.el.id, {
+        state.groupsConfig.set(prevGroup.id, {
           ...prevGroup,
-          lastElement: (prevElement as FocusableElement).el.id
+          lastElement: (prevElement as FocusableElement).id
         })
       }
       prevGroup.onBlur?.({

--- a/src/handlers/getNextElementHandler.ts
+++ b/src/handlers/getNextElementHandler.ts
@@ -8,5 +8,5 @@ export default function getNextElementHandler (state: ArrowNavigationState) {
     direction,
     state,
     inGroup
-  })?.el.id ?? null
+  })?.id ?? null
 }

--- a/src/handlers/getNextGroupHandler.ts
+++ b/src/handlers/getNextGroupHandler.ts
@@ -7,5 +7,5 @@ export default function getNextGroupHandler (state: ArrowNavigationState) {
     fromElement: state.elements.get(elementId || '') as FocusableElement,
     direction,
     state
-  })?.group.el.id ?? null
+  })?.group.id ?? null
 }

--- a/src/handlers/globalFocusHandler.ts
+++ b/src/handlers/globalFocusHandler.ts
@@ -5,7 +5,7 @@ const globalFocusHandler = (state: ArrowNavigationState, event: FocusEvent) => {
   const target = event.target as HTMLElement
   const currentElement = getCurrentElement(state)
   if (!currentElement) return
-  if (target && target.id !== currentElement.el.id) {
+  if (target && target.id !== currentElement.id) {
     currentElement.el.focus()
   }
 }

--- a/src/handlers/registerElementHandler.test.ts
+++ b/src/handlers/registerElementHandler.test.ts
@@ -37,7 +37,8 @@ describe('registerElementHandler', () => {
     registerElement(element, groupId)
 
     expect(state.elements.has(element.id)).toBe(true)
-    expect(state.groups.get(groupId)?.elements.get(element.id)?.el).toBe(element)
+    expect(state.elements.get(element.id)?.el).toBe(element)
+    expect(state.groups.get('group-0')?.elements.has(element.id)).toBe(true)
   })
 
   it('should throw an error if the element id is not defined', () => {
@@ -76,7 +77,7 @@ describe('registerElementHandler', () => {
     element.id = 'element-5-0'
     registerElement(element, 'group-5')
 
-    expect(onChangeElement).toHaveBeenCalledWith({ el: element, group: 'group-5' })
+    expect(onChangeElement).toHaveBeenCalledWith({ el: element, group: 'group-5', id: 'element-5-0' })
   })
 
   it('should throw an error if the element is not focusable', () => {
@@ -94,6 +95,7 @@ describe('registerElementHandler', () => {
     group.id = 'group-10'
 
     state.groupsConfig.set(group.id, {
+      id: group.id,
       el: group
     })
 

--- a/src/handlers/registerElementHandler.ts
+++ b/src/handlers/registerElementHandler.ts
@@ -39,6 +39,7 @@ export default function registerElementHandler (
     }
 
     const focusableElement = {
+      id: element.id,
       el: element,
       group,
       ...options
@@ -51,14 +52,15 @@ export default function registerElementHandler (
     const existentGroupConfig = state.groupsConfig.get(group)
 
     if (!existentGroup) {
-      const elementsMap = new Map().set(element.id, focusableElement)
+      const elementsSet = new Set<string>().add(element.id)
       state.groups.set(group, {
-        elements: elementsMap,
+        id: group,
+        elements: elementsSet,
         el: existentGroupConfig?.el || null as unknown as HTMLElement
       })
       emit(EVENTS.GROUPS_CHANGED, state.groups)
     } else {
-      existentGroup.elements.set(element.id, focusableElement)
+      existentGroup.elements.add(element.id)
     }
 
     if (!state.currentElement && !isElementDisabled(focusableElement.el)) {

--- a/src/handlers/registerGroupHandler.test.ts
+++ b/src/handlers/registerGroupHandler.test.ts
@@ -39,13 +39,13 @@ describe('registerGroupHandler', () => {
     const element = document.createElement('button')
     element.id = `element-0-${groupTotalElements}`
 
-    expect(state.groupsConfig.get(group.el.id)?.viewportSafe).toBeUndefined()
+    expect(state.groupsConfig.get(group.id)?.viewportSafe).toBeUndefined()
 
     registerGroup(group.el, {
       viewportSafe: true
     })
 
-    expect(state.groupsConfig.get(group.el.id)?.viewportSafe).toBe(true)
+    expect(state.groupsConfig.get(group.id)?.viewportSafe).toBe(true)
     expect(state.groups.get(groupId)?.elements.size).toBe(groupTotalElements)
   })
 })

--- a/src/handlers/registerGroupHandler.ts
+++ b/src/handlers/registerGroupHandler.ts
@@ -30,10 +30,11 @@ export default function registerGroupHandler (
 
     const existentGroup = state.groups.get(id)
 
-    const prevElements: FocusableGroup['elements'] = existentGroup?.elements || new Map()
+    const prevElements: FocusableGroup['elements'] = existentGroup?.elements || new Set()
     const prevConfig = state.groupsConfig.get(id)
 
     state.groups.set(id, {
+      id,
       elements: prevElements,
       el: element
     })
@@ -42,6 +43,7 @@ export default function registerGroupHandler (
     state.groupsConfig.set(id, {
       ...defaultGroupConfig,
       ...options,
+      id,
       lastElement: prevConfig?.lastElement || undefined,
       el: element
     })

--- a/src/handlers/unregisterElementHandler.test.ts
+++ b/src/handlers/unregisterElementHandler.test.ts
@@ -21,7 +21,7 @@ describe('unregisterElementHandler', () => {
 
     expect(state.elements.has(element.id)).toBe(false)
     expect(state.groups.get('group-0')?.elements.has(element.id)).toBe(false)
-    expect(state.groups.get('group-0')?.elements.get('element-0-3')).toBeUndefined()
+    expect(state.groups.get('group-0')?.elements.has('element-0-3')).toBe(false)
   })
 
   it('should delete the group if it is empty', () => {
@@ -52,7 +52,7 @@ describe('unregisterElementHandler', () => {
 
     expect(state.elements.has(elementId)).toBe(false)
     expect(state.groups.get('group-0')?.elements.has(elementId)).toBe(false)
-    expect(state.groups.get('group-0')?.elements.get('element-0-3')).toBeUndefined()
+    expect(state.groups.get('group-0')?.elements.has('element-0-3')).toBe(false)
   })
 
   it('should focus the next element if the current element is unregistered', () => {
@@ -63,6 +63,6 @@ describe('unregisterElementHandler', () => {
     element.id = 'element-0-0'
     unregisterElement(element)
 
-    expect(onFocusChange).toHaveBeenCalledWith(state.groups.get('group-0')?.elements.get('element-0-1'), undefined)
+    expect(onFocusChange).toHaveBeenCalledWith(state.elements.get('element-0-1'), undefined)
   })
 })

--- a/src/handlers/utils/findClosestElementInGroup.test.ts
+++ b/src/handlers/utils/findClosestElementInGroup.test.ts
@@ -13,39 +13,42 @@ describe('findClosestElementInGroup', () => {
 
   it('should return the closest element in the group for given direction', () => {
     const group = state.groups.get('group-0') as FocusableGroup
-    const arrayGroup = Array.from(group.elements.values())
     state.currentElement = 'element-0-0'
 
     const closestElement = findClosestElementInGroup({
       direction: 'down',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true
     })
-    expect(closestElement).toBe(group.elements.get('element-0-1'))
+    expect(closestElement).toBe(state.elements.get('element-0-1'))
 
     state.currentElement = 'element-0-1'
 
     const closestElement2 = findClosestElementInGroup({
       direction: 'up',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true
     })
-    expect(closestElement2).toBe(group.elements.get('element-0-0'))
+    expect(closestElement2).toBe(state.elements.get('element-0-0'))
 
     const closestElement3 = findClosestElementInGroup({
       direction: 'right',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      state,
+      candidateElements: group.elements,
       isViewportSafe: true
     })
     expect(closestElement3).toBe(null)
 
     const closestElement4 = findClosestElementInGroup({
+      state,
       direction: 'left',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
       isViewportSafe: true
     })
     expect(closestElement4).toBe(null)
@@ -53,112 +56,120 @@ describe('findClosestElementInGroup', () => {
 
   it('should return null if the next candidate is out of viewport if isViewportSafe is true', () => {
     const group = state.groups.get('group-1') as FocusableGroup
-    const arrayGroup = Array.from(group.elements.values())
     state.currentElement = 'element-1-2'
 
     const closestElement = findClosestElementInGroup({
       direction: 'right',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true
     })
-    expect(group.elements.get('element-1-3')).not.toBeUndefined()
+    expect(state.elements.get('element-1-3')).not.toBeUndefined()
     expect(closestElement).toBe(null)
   })
 
   it('should return the closest element in the group for given direction if isViewportSafe is false', () => {
     const group = state.groups.get('group-1') as FocusableGroup
-    const arrayGroup = Array.from(group.elements.values())
     state.currentElement = 'element-1-2'
 
     const closestElement = findClosestElementInGroup({
       direction: 'right',
+      state,
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup
+      candidateElements: group.elements
     })
-    expect(group.elements.get('element-1-3')).not.toBeUndefined()
-    expect(closestElement).toBe(group.elements.get('element-1-3'))
+    expect(state.elements.get('element-1-3')).not.toBeUndefined()
+    expect(closestElement).toBe(state.elements.get('element-1-3'))
   })
 
   it('should return null if the currentElement is null', () => {
+    const group = state.groups.get('group-0') as FocusableGroup
     state.currentElement = null
 
     const closestElement = findClosestElementInGroup({
       direction: 'down',
       currentFocusElement: state.currentElement as unknown as FocusableElement,
-      candidateElements: Array.from((state.groups.get('group-0') as FocusableGroup).elements.values())
+      candidateElements: group.elements,
+      state
     })
     expect(closestElement).toBe(null)
   })
 
   it('should return null if the currentElement is not in the group', () => {
     state.currentElement = 'element-0-0'
+    const group = state.groups.get('group-1') as FocusableGroup
 
     const closestElement = findClosestElementInGroup({
       direction: 'down',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: Array.from((state.groups.get('group-1') as FocusableGroup).elements.values())
+      candidateElements: group.elements,
+      state
     })
     expect(closestElement).toBe(null)
   })
 
   it('should return the closest element, not matters the direction, with allValidCandidates', () => {
     const group = state.groups.get('group-0') as FocusableGroup
-    const arrayGroup = Array.from(group.elements.values())
     state.currentElement = 'element-0-0'
 
     const closestElement = findClosestElementInGroup({
       direction: 'down',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true,
       allValidCandidates: true
     })
-    expect(closestElement).toBe(group.elements.get('element-0-1'))
+    expect(closestElement).toBe(state.elements.get('element-0-1'))
 
     state.currentElement = 'element-0-1'
 
     const closestElement2 = findClosestElementInGroup({
       direction: 'up',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true,
       allValidCandidates: true
     })
-    expect(closestElement2).toBe(group.elements.get('element-0-0'))
+    expect(closestElement2).toBe(state.elements.get('element-0-0'))
 
     const closestElement3 = findClosestElementInGroup({
       direction: 'right',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true,
       allValidCandidates: true
     })
-    expect(closestElement3).toBe(group.elements.get('element-0-0'))
+    expect(closestElement3).toBe(state.elements.get('element-0-0'))
 
     const closestElement4 = findClosestElementInGroup({
       direction: 'left',
       currentFocusElement: getCurrentElement(state) as FocusableElement,
-      candidateElements: arrayGroup,
+      candidateElements: group.elements,
+      state,
       isViewportSafe: true,
       allValidCandidates: true
     })
-    expect(closestElement4).toBe(group.elements.get('element-0-0'))
+    expect(closestElement4).toBe(state.elements.get('element-0-0'))
   })
 
   it('should return the closest element, but not the disabled element', () => {
     const group1 = state.groups.get('group-1') as FocusableGroup
 
-    group1.elements.get('element-1-1')?.el.setAttribute('disabled', '')
+    state.elements.get('element-1-1')?.el.setAttribute('disabled', '')
 
     const closesElement = findClosestElementInGroup({
       direction: 'right',
-      currentFocusElement: group1.elements.get('element-1-0') as FocusableElement,
-      candidateElements: Array.from(group1.elements.values()),
+      currentFocusElement: state.elements.get('element-1-0') as FocusableElement,
+      candidateElements: group1.elements,
+      state,
       isViewportSafe: true,
       allValidCandidates: false
     })
 
-    expect(closesElement).toBe(group1.elements.get('element-1-2'))
+    expect(closesElement).toBe(state.elements.get('element-1-2'))
   })
 })

--- a/src/handlers/utils/findClosestElementInGroup.ts
+++ b/src/handlers/utils/findClosestElementInGroup.ts
@@ -1,4 +1,4 @@
-import type { FocusableElement } from '@/types'
+import type { ArrowNavigationState, FocusableElement } from '@/types'
 import getEuclideanDistance from './getEuclideanDistance'
 import getReferencePointsByDirection from './getReferencePointsByDirection'
 import isElementDisabled from './isElementDisabled'
@@ -11,23 +11,26 @@ interface Result {
 
 interface Props {
   currentFocusElement: FocusableElement
-  candidateElements: FocusableElement[]
+  candidateElements: Set<string>
   direction: string | undefined
   threshold?: number
   isViewportSafe?: boolean
   allValidCandidates?: boolean
+  state: ArrowNavigationState
 }
 
 export default function findClosestElementInGroup ({
   candidateElements,
   currentFocusElement,
+  state,
   direction,
   threshold = 0,
   isViewportSafe = false,
   allValidCandidates
 }: Props): FocusableElement | null {
-  const result = candidateElements.reduce<Result>(
-    (acc, candidate) => {
+  const result = Array.from(candidateElements?.values() || []).reduce<Result>(
+    (acc, id) => {
+      const candidate = state.elements.get(id) as FocusableElement
       if (
         candidate.el === currentFocusElement?.el
         || !currentFocusElement?.el

--- a/src/handlers/utils/findClosestGroup.test.ts
+++ b/src/handlers/utils/findClosestGroup.test.ts
@@ -68,8 +68,8 @@ describe('findClosestGroup', () => {
   it('should return the subsequent best candidate if the next candidate doesnt have focusable elements', () => {
     state.currentElement = 'element-1-0'
 
-    state.groups.get('group-2')?.elements.forEach(element => {
-      element.el.setAttribute('disabled', 'true')
+    state.groups.get('group-2')?.elements.forEach(id => {
+      state.elements.get(id)?.el.setAttribute('disabled', 'true')
     })
 
     const closestGroup = findClosestGroup({
@@ -78,6 +78,6 @@ describe('findClosestGroup', () => {
       candidateGroups: state.groups,
       state
     })
-    expect(closestGroup?.group?.el.id).toBe('group-3')
+    expect(closestGroup?.group?.id).toBe('group-3')
   })
 })

--- a/src/handlers/utils/findClosestGroup.ts
+++ b/src/handlers/utils/findClosestGroup.ts
@@ -83,7 +83,7 @@ export default function findClosestGroup ({
 
     if (!element) {
       const filteredGroups = new Map(candidateGroups)
-      filteredGroups.delete(result.closestGroup.el.id)
+      filteredGroups.delete(result.closestGroup.id)
       return findClosestGroup({
         direction,
         currentElement,

--- a/src/handlers/utils/findNextByDirection.test.ts
+++ b/src/handlers/utils/findNextByDirection.test.ts
@@ -1,0 +1,189 @@
+import getViewNavigationStateMock from '@/__mocks__/viewNavigationState.mock'
+import { ArrowNavigationState, FocusableElement, FocusableGroup, FocusableGroupConfig } from '@/types'
+import findNextByDirection from './findNextByDirection'
+
+describe('findNextByDirection', () => {
+  let state: ArrowNavigationState
+  beforeEach(() => {
+    state = getViewNavigationStateMock()
+  })
+
+  it('should return the next element setted at direction', () => {
+    const nextElement = state.elements.get('element-0-1') as FocusableElement
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: nextElement.id
+      }
+    })
+    const element = state.elements.get('element-0-0') as FocusableElement
+    const next = findNextByDirection({
+      direction: 'right',
+      fromElement: element,
+      state
+    })
+    expect(next).toBe(nextElement)
+  })
+
+  it('should return the next element from the group setted at direction', () => {
+    const nextElement = state.elements.get('element-1-0') as FocusableElement
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        down: {
+          id: 'group-1',
+          kind: 'group'
+        }
+      }
+    })
+    const next = findNextByDirection({
+      direction: 'down',
+      fromElement: state.elements.get('element-0-0') as FocusableElement,
+      state
+    })
+    expect(next).toBe(nextElement)
+  })
+
+  it('should return null if the next element is setted null', () => {
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: null
+      }
+    })
+    const next = findNextByDirection({
+      direction: 'right',
+      fromElement: state.elements.get('element-0-0') as FocusableElement,
+      state
+    })
+    expect(next).toBe(null)
+  })
+
+  it('should return the subsequent element if the next element is disabled', () => {
+    const nextElement = state.elements.get('element-0-1') as FocusableElement
+    const subsequentElement = state.elements.get('element-0-2') as FocusableElement
+    nextElement.el.setAttribute('disabled', 'true')
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: nextElement.id
+      }
+    })
+    state.elements.set('element-0-1', {
+      ...state.elements.get('element-0-1') as FocusableElement,
+      nextByDirection: {
+        right: subsequentElement.id
+      }
+    })
+    const element = state.elements.get('element-0-0') as FocusableElement
+    const next = findNextByDirection({
+      direction: 'right',
+      fromElement: element,
+      state
+    })
+    expect(next).toBe(subsequentElement)
+  })
+
+  it('should return the subsequent group if the next group doesnt have valid candidates', () => {
+    const subsequentGroup = state.groups.get('group-2') as FocusableGroup
+    const nextGroup = state.groups.get('group-1') as FocusableGroup
+
+    nextGroup.elements.forEach(id => {
+      state.elements.get(id)?.el.setAttribute('disabled', 'true')
+    })
+
+    state.elements.set('element-0-0', {
+      ...state.groupsConfig.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: {
+          id: 'group-1',
+          kind: 'group'
+        }
+      }
+    })
+
+    state.groupsConfig.set('group-1', {
+      ...state.groupsConfig.get('group-1') as FocusableGroup,
+      nextGroupByDirection: {
+        right: subsequentGroup.id
+      }
+    })
+
+    state.groupsConfig.set('group-2', {
+      ...state.groupsConfig.get('group-2') as FocusableGroup,
+      firstElement: 'element-2-0'
+    })
+
+    const next = findNextByDirection({
+      direction: 'right',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+
+    expect(next).toBe(state.elements.get('element-2-0'))
+    expect(next?.group).toBe(subsequentGroup.id)
+  })
+
+  it('should return undefined if the next group doesnt exists', () => {
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: {
+          id: 'non-existent-group',
+          kind: 'group'
+        }
+      }
+    })
+
+    const next = findNextByDirection({
+      direction: 'right',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+
+    expect(next).toBe(undefined)
+  })
+
+  it('should return undefined if nextByDirection is undefined', () => {
+    const next = findNextByDirection({
+      direction: 'right',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+
+    expect(next).toBe(undefined)
+  })
+
+  it('should return undefined if subsequent group doesnt exists', () => {
+    const nextGroup = state.groups.get('group-1') as FocusableGroup
+
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: {
+          id: nextGroup.id,
+          kind: 'group'
+        }
+      }
+    })
+
+    nextGroup.elements.forEach(id => {
+      state.elements.get(id)?.el.setAttribute('disabled', 'true')
+    })
+
+    state.groupsConfig.set('group-1', {
+      ...state.groupsConfig.get('group-1') as FocusableGroupConfig,
+      nextGroupByDirection: {
+        right: 'non-existent-group'
+      }
+    })
+
+    const next = findNextByDirection({
+      direction: 'right',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+
+    expect(next).toBe(undefined)
+  })
+})

--- a/src/handlers/utils/findNextByDirection.ts
+++ b/src/handlers/utils/findNextByDirection.ts
@@ -1,0 +1,60 @@
+import type { ArrowNavigationState, Direction, FocusableElement, FocusableWithKind } from '@/types'
+import findNextGroupElement from './findNextGroupElement'
+import findNextGroupByDirection from './findNextGroupByDirection'
+import isElementDisabled from './isElementDisabled'
+import getFocusableWithKind from './isFocusableWithKind'
+
+interface Props {
+  direction: string | undefined
+  state: ArrowNavigationState
+  fromElement: FocusableElement
+}
+
+export default function findNextByDirection ({
+  fromElement,
+  direction,
+  state
+}: Props): FocusableElement | null | undefined {
+  const selectedElement = fromElement
+  const candidateGroups = state.groups
+
+  const nextByDirection = selectedElement.nextByDirection?.[direction as Direction]
+  if (nextByDirection === null) return null
+  if (nextByDirection === undefined) return undefined
+
+  const focusableWithKind: FocusableWithKind = getFocusableWithKind(nextByDirection)
+
+  if (focusableWithKind.kind === 'element') {
+    const nextElement = state.elements.get(focusableWithKind.id as string)
+    if (nextElement) {
+      if (!isElementDisabled(nextElement.el)) return nextElement
+      return findNextByDirection({
+        fromElement: nextElement,
+        direction,
+        state
+      })
+    }
+  }
+  if (focusableWithKind.kind === 'group') {
+    const nextGroup = candidateGroups.get(focusableWithKind.id as string)
+    if (nextGroup) {
+      const element = findNextGroupElement({
+        direction,
+        nextGroup,
+        state,
+        fromElement: selectedElement
+      })
+      if (element) return element
+
+      return findNextGroupByDirection({
+        fromElement: selectedElement,
+        direction,
+        fromGroup: nextGroup,
+        state,
+        groups: candidateGroups
+      })?.element
+    }
+  }
+
+  return undefined
+}

--- a/src/handlers/utils/findNextElement.test.ts
+++ b/src/handlers/utils/findNextElement.test.ts
@@ -60,4 +60,41 @@ describe('findNextElement', () => {
 
     expect(nextElement).toBe(state.elements.get('element-0-2'))
   })
+
+  it('should return the next group element if setted a group with nextByDirection', () => {
+    const element = state.elements.get('element-0-0') as FocusableElement
+
+    element.nextByDirection = {
+      down: {
+        id: 'group-1',
+        kind: 'group'
+      }
+    }
+
+    const nextElement = findNextElement({
+      direction: 'down',
+      fromElement: getCurrentElement(state) as FocusableElement,
+      state,
+      inGroup: true
+    })
+
+    expect(nextElement).toBe(state.elements.get('element-1-0'))
+  })
+
+  it('should return null if the next element is setted null', () => {
+    const element = state.elements.get('element-0-0') as FocusableElement
+
+    element.nextByDirection = {
+      down: null
+    }
+
+    const nextElement = findNextElement({
+      direction: 'down',
+      fromElement: getCurrentElement(state) as FocusableElement,
+      state,
+      inGroup: true
+    })
+
+    expect(nextElement).toBe(null)
+  })
 })

--- a/src/handlers/utils/findNextElement.ts
+++ b/src/handlers/utils/findNextElement.ts
@@ -2,6 +2,7 @@ import type { ArrowNavigationState, FocusableElement, FocusableGroup } from '@/t
 import findClosestElementInGroup from './findClosestElementInGroup'
 import findNextElementByDirection from './findNextElementByDirection'
 import findNextGroup from './findNextGroup'
+import findNextByDirection from './findNextByDirection'
 
 interface Props {
   direction: string | undefined
@@ -22,7 +23,19 @@ export default function findNextElement ({
   const fromGroupConfig = state.groupsConfig.get(selectedElement?.group)
   let nextElement: FocusableElement | null | undefined
 
-  if (selectedElement?.nextElementByDirection) {
+  if (selectedElement?.nextByDirection) {
+    nextElement = findNextByDirection({
+      direction,
+      fromElement: selectedElement,
+      state
+    })
+    if (nextElement === null) return null
+  } else if (selectedElement?.nextElementByDirection) {
+    /**
+     * If the current element has a nextElementByDirection property, we use it
+     * to find the next element.
+     * This will be removed in the next major version.
+     */
     nextElement = findNextElementByDirection({
       fromElement: selectedElement,
       direction,
@@ -34,7 +47,8 @@ export default function findNextElement ({
   if (!nextElement) {
     nextElement = findClosestElementInGroup({
       direction,
-      candidateElements: Array.from(fromGroup?.elements.values() || []),
+      candidateElements: fromGroup?.elements,
+      state,
       currentFocusElement: selectedElement,
       threshold: fromGroupConfig?.threshold,
       isViewportSafe: fromGroupConfig?.viewportSafe

--- a/src/handlers/utils/findNextElementByDirection.ts
+++ b/src/handlers/utils/findNextElementByDirection.ts
@@ -7,6 +7,10 @@ interface Props {
   fromElement: FocusableElement
 }
 
+/**
+ * @deprecated
+ * Use findNextByDirection instead
+ */
 export default function findNextElementByDirection ({
   fromElement,
   direction,

--- a/src/handlers/utils/findNextGroup.test.ts
+++ b/src/handlers/utils/findNextGroup.test.ts
@@ -14,7 +14,7 @@ describe('findNextGroup', () => {
     const group1 = state.groups.get('group-1') as FocusableGroup
 
     group0Config.nextGroupByDirection = {
-      right: group1.el.id
+      right: group1.id
     }
 
     const nextGroup = findNextGroup({
@@ -43,7 +43,7 @@ describe('findNextGroup', () => {
     const group2 = state.groups.get('group-2') as FocusableGroup
 
     group1Config.nextGroupByDirection = {
-      down: group2.el.id
+      down: group2.id
     }
 
     const nextGroup = findNextGroup({

--- a/src/handlers/utils/findNextGroup.ts
+++ b/src/handlers/utils/findNextGroup.ts
@@ -25,7 +25,7 @@ export default function findNextGroup ({
 }: Props): GroupAndElement | null {
   const selectedElement = fromElement || getCurrentElement(state) as FocusableElement
   const candidateGroups = groups || state.groups
-  const currentGroupConfig = state.groupsConfig.get(fromGroup?.el.id || selectedElement?.group || '')
+  const currentGroupConfig = state.groupsConfig.get(fromGroup?.id || selectedElement?.group || '')
 
   let nextGroupAndElement: GroupAndElement | null | undefined
 

--- a/src/handlers/utils/findNextGroupByDirection.test.ts
+++ b/src/handlers/utils/findNextGroupByDirection.test.ts
@@ -15,7 +15,7 @@ describe('findNextGroupByDirection', () => {
     const group1 = state.groups.get('group-1') as FocusableGroup
 
     group0Config.nextGroupByDirection = {
-      right: group1.el.id
+      right: group1.id
     }
 
     const nextGroup = findNextGroupByDirection({
@@ -32,16 +32,16 @@ describe('findNextGroupByDirection', () => {
 
     const group1 = state.groups.get('group-1') as FocusableGroup
 
-    group1.elements.forEach(element => {
-      element.el.setAttribute('disabled', 'true')
+    group1.elements.forEach(id => {
+      state.elements.get(id)?.el.setAttribute('disabled', 'true')
     })
 
     group0Config.nextGroupByDirection = {
-      right: group1Config.el.id
+      right: group1Config.id
     }
 
     group1Config.nextGroupByDirection = {
-      right: group2.el.id
+      right: group2.id
     }
 
     const nextGroup = findNextGroupByDirection({

--- a/src/handlers/utils/findNextGroupByDirection.ts
+++ b/src/handlers/utils/findNextGroupByDirection.ts
@@ -25,7 +25,7 @@ export default function findNextGroupByDirection ({
   const selectedElement = fromElement || getCurrentElement(state) as FocusableElement
   const candidateGroups = groups || state.groups
   const currentGroupConfig = state.groupsConfig.get(
-    fromGroup?.el.id
+    fromGroup?.id
     || selectedElement?.group
     || ''
   )
@@ -48,6 +48,7 @@ export default function findNextGroupByDirection ({
     if (element) return ({ group: nextGroup, element })
 
     return findNextGroupByDirection({
+      fromElement: selectedElement,
       direction,
       fromGroup: nextGroup,
       state,

--- a/src/handlers/utils/findNextGroupElement.test.ts
+++ b/src/handlers/utils/findNextGroupElement.test.ts
@@ -12,26 +12,25 @@ describe('findNextGroupElement', () => {
   })
 
   it('should return the next group element without options', () => {
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
-    const fromElement = currentGroup.elements.get('element-0-0') as FocusableElement
+    const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const nextGroup = state.groups.get('group-1') as FocusableGroup
 
     const element = findNextGroupElement({ fromElement, direction: 'right', state, nextGroup })
 
-    expect(element).toBe(nextGroup.elements.get('element-1-0'))
+    expect(element).toBe(state.elements.get('element-1-0'))
   })
 
   it('should return the next group element with manual next group', () => {
     const nextGroup = state.groups.get('group-2') as FocusableGroup
     state.groupsConfig.set('group-0', {
+      id: 'group-0',
       el: state.groups.get('group-0')?.el as HTMLElement,
       nextGroupByDirection: {
-        right: nextGroup.el.id
+        right: nextGroup.id
       }
     })
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
-    const fromElement = currentGroup.elements.get('element-0-0') as FocusableElement
+    const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const element = findNextGroupElement({
       nextGroup,
@@ -40,16 +39,17 @@ describe('findNextGroupElement', () => {
       state
     })
 
-    expect(element).toBe(nextGroup.elements.get('element-2-0'))
+    expect(element).toBe(state.elements.get('element-2-0'))
   })
 
   it('should return the next group element with firstElement setted', () => {
     const nextGroup = state.groups.get('group-1') as FocusableGroup
     state.groupsConfig.set('group-1', {
+      id: 'group-1',
       el: nextGroup.el as HTMLElement,
       firstElement: 'element-1-2'
     })
-    const nextElement = nextGroup.elements.get('element-1-2')
+    const nextElement = state.elements.get('element-1-2')
     const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const element = findNextGroupElement({
@@ -65,11 +65,12 @@ describe('findNextGroupElement', () => {
   it('should return the next group element if first is disabled but have other candidate', () => {
     const nextGroup = state.groups.get('group-1') as FocusableGroup
     state.groupsConfig.set('group-1', {
+      id: 'group-1',
       el: nextGroup.el as HTMLElement,
       firstElement: 'element-1-0'
     })
-    nextGroup.elements.get('element-1-0')?.el.setAttribute('disabled', 'true')
-    const nextElement = nextGroup.elements.get('element-1-1')
+    state.elements.get('element-1-0')?.el.setAttribute('disabled', 'true')
+    const nextElement = state.elements.get('element-1-1')
     const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const element = findNextGroupElement({
@@ -85,12 +86,13 @@ describe('findNextGroupElement', () => {
   it('should return the next group element if first is disabled but have other subsequent candidate', () => {
     const nextGroup = state.groups.get('group-1') as FocusableGroup
     state.groupsConfig.set('group-1', {
+      id: 'group-1',
       el: nextGroup.el as HTMLElement,
       firstElement: 'element-1-0'
     })
-    nextGroup.elements.get('element-1-0')?.el.setAttribute('disabled', 'true')
-    nextGroup.elements.get('element-1-1')?.el.setAttribute('disabled', 'true')
-    const nextElement = nextGroup.elements.get('element-1-2')
+    state.elements.get('element-1-0')?.el.setAttribute('disabled', 'true')
+    state.elements.get('element-1-1')?.el.setAttribute('disabled', 'true')
+    const nextElement = state.elements.get('element-1-2')
     const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const element = findNextGroupElement({
@@ -106,13 +108,14 @@ describe('findNextGroupElement', () => {
   it('should return null if the firstElement is disabled and have setted null candidate on direction (Last at his direction)', () => {
     const nextGroup = state.groups.get('group-1') as FocusableGroup
     state.groupsConfig.set('group-1', {
+      id: 'group-1',
       el: nextGroup.el as HTMLElement,
       firstElement: 'element-1-0'
     });
-    (nextGroup.elements.get('element-1-0') as FocusableElement).nextElementByDirection = {
+    (state.elements.get('element-1-0') as FocusableElement).nextElementByDirection = {
       right: null
     }
-    nextGroup.elements.get('element-1-0')?.el.setAttribute('disabled', 'true')
+    state.elements.get('element-1-0')?.el.setAttribute('disabled', 'true')
     const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const element = findNextGroupElement({
@@ -127,6 +130,7 @@ describe('findNextGroupElement', () => {
 
   it('should return null if the currentGroup doesnt exists', () => {
     const fromElement = {
+      id: 'non-existing',
       el: document.createElement('div'),
       group: 'non-existing-group'
     }
@@ -143,13 +147,13 @@ describe('findNextGroupElement', () => {
 
   it('should return null if the manual setted next group is null', () => {
     state.groupsConfig.set('group-0', {
+      id: 'group-0',
       el: state.groups.get('group-0')?.el as HTMLElement,
       nextGroupByDirection: {
         right: null
       }
     })
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
-    const fromElement = currentGroup.elements.get('element-0-0') as FocusableElement
+    const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const element = findNextGroupElement({
       nextGroup: null as unknown as FocusableGroup,
@@ -162,8 +166,7 @@ describe('findNextGroupElement', () => {
   })
 
   it('should return closest if next group config is not setted', () => {
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
-    const fromElement = currentGroup.elements.get('element-0-0') as FocusableElement
+    const fromElement = state.elements.get('element-0-0') as FocusableElement
 
     const nextGroup = state.groups.get('group-1') as FocusableGroup
     state.groupsConfig.delete('group-1')
@@ -175,7 +178,7 @@ describe('findNextGroupElement', () => {
       state
     })
 
-    expect(element).toBe(nextGroup.elements.get('element-1-0'))
+    expect(element).toBe(state.elements.get('element-1-0'))
   })
 
   it('should return the lastElement if saveLast is true and has lastElement', () => {

--- a/src/handlers/utils/findNextGroupElement.ts
+++ b/src/handlers/utils/findNextGroupElement.ts
@@ -18,7 +18,7 @@ export default function findNextGroupElement ({
 }: Props): FocusableElement | null {
   if (!nextGroup) return null
   let nextElement: FocusableElement | null = null
-  const config = state.groupsConfig.get(nextGroup.el.id)
+  const config = state.groupsConfig.get(nextGroup.id)
 
   if (config) {
     const firstElement = (config.saveLast && config.lastElement) || config.firstElement
@@ -42,8 +42,9 @@ export default function findNextGroupElement ({
 
   nextElement = findClosestElementInGroup({
     direction,
-    candidateElements: Array.from(nextGroup.elements.values()),
+    candidateElements: nextGroup.elements,
     currentFocusElement: fromElement,
+    state,
     threshold: config?.threshold,
     isViewportSafe: config?.viewportSafe,
     allValidCandidates: true

--- a/src/handlers/utils/focusNextElement.test.ts
+++ b/src/handlers/utils/focusNextElement.test.ts
@@ -1,4 +1,4 @@
-import { ArrowNavigationState, FocusableElement, FocusableGroup, FocusableGroupConfig } from '@/types'
+import { ArrowNavigationState, FocusableElement, FocusableGroupConfig } from '@/types'
 import getCurrentElement from '@/utils/getCurrentElement'
 import getViewNavigationStateMock from '../../__mocks__/viewNavigationState.mock'
 import focusNextElement from './focusNextElement'
@@ -13,35 +13,33 @@ describe('focusNextElement', () => {
   })
 
   it('should focus the next element', () => {
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
     state.currentElement = 'element-0-0'
 
     const onFocusChange = jest.fn(element => {
-      state.currentElement = element.el.id
+      state.currentElement = element.id
     })
 
     focusNextElement({ direction: 'down', state, onChangeCurrentElement: onFocusChange })
 
     expect(state.currentElement).toBe('element-0-1')
-    expect(onFocusChange).toHaveBeenCalledWith(currentGroup.elements.get('element-0-1'), 'down')
+    expect(onFocusChange).toHaveBeenCalledWith(state.elements.get('element-0-1'), 'down')
   })
 
   it('should focus the next element with manual next element', () => {
-    const currentGroup = state.groups.get('group-0') as FocusableGroup
-    const currentElement = currentGroup.elements.get('element-0-0') as FocusableElement
+    const currentElement = state.elements.get('element-0-0') as FocusableElement
     currentElement.nextElementByDirection = {
       down: 'element-0-2'
     }
     state.currentElement = 'element-0-0'
 
     const onFocusChange = jest.fn(element => {
-      state.currentElement = element.el.id
+      state.currentElement = element.id
     })
 
     focusNextElement({ direction: 'down', state, onChangeCurrentElement: onFocusChange })
 
     expect(state.currentElement).toBe('element-0-2')
-    expect(onFocusChange).toHaveBeenCalledWith(currentGroup.elements.get('element-0-2'), 'down')
+    expect(onFocusChange).toHaveBeenCalledWith(state.elements.get('element-0-2'), 'down')
   })
 
   it('should focus nothing with manual null', () => {
@@ -74,7 +72,7 @@ describe('focusNextElement', () => {
     state.groupsConfig.delete('group-0')
 
     const onFocusChange = jest.fn(element => {
-      state.currentElement = element.el.id
+      state.currentElement = element.id
     })
 
     focusNextElement({ direction: 'down', state, onChangeCurrentElement: onFocusChange })

--- a/src/handlers/utils/isFocusableWithKind.ts
+++ b/src/handlers/utils/isFocusableWithKind.ts
@@ -1,0 +1,9 @@
+import type { FocusableWithKind } from '@/types'
+
+export default function getFocusableWithKind (
+  focusable: FocusableWithKind | string
+): FocusableWithKind {
+  return typeof focusable === 'string'
+    ? { id: focusable, kind: 'element' }
+    : focusable
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,7 @@ export type {
   ArrowNavigationState,
   Direction,
   FocusableElementOptions,
-  FocusableGroupOptions
+  FocusableGroupOptions,
+  FocusableWithKind,
+  FocusableByDirection
 } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,15 @@ export type FocusType = 'first' | 'closest' | 'manual'
 
 export type Point = { x: number, y: number }
 
+export type FocusableWithKind = {
+  id: string
+  kind: 'group' | 'element'
+}
+
+export type FocusableByDirection = {
+  [key in Direction]?: string | FocusableWithKind | null
+}
+
 export type ElementByDirection = {
   [key in Direction]?: string | null
 }
@@ -24,20 +33,26 @@ type BlurEventResult<T> = EventResult<T> & {
 }
 
 export type Focusable = {
+  id: string
   el: HTMLElement
 }
 
 export type FocusableElement = Focusable & {
   group: string
+  /**
+   * @deprecated
+   * Use nextByDirection instead. This property will be removed in the next major version.
+   */
   nextElementByDirection?: ElementByDirection
+  nextByDirection?: FocusableByDirection
   onFocus?: (result: FocusEventResult<FocusableElement>) => void
   onBlur?: (result: BlurEventResult<FocusableElement>) => void
 }
 
-export type FocusableElementOptions = Omit<FocusableElement, 'el' | 'group'>
+export type FocusableElementOptions = Omit<FocusableElement, 'el' | 'group' | 'id'>
 
 export type FocusableGroup = Focusable & {
-  elements: Map<string, FocusableElement>
+  elements: Set<string>
 }
 
 export type FocusableGroupConfig = Focusable & {
@@ -52,7 +67,7 @@ export type FocusableGroupConfig = Focusable & {
   keepFocus?: boolean
 }
 
-export type FocusableGroupOptions = Omit<FocusableGroupConfig, 'el'>
+export type FocusableGroupOptions = Omit<FocusableGroupConfig, 'el' | 'id'>
 
 export type ArrowNavigationState = {
   currentElement: string | null,


### PR DESCRIPTION
- Add nextByDirection to elements, now accepts groups too
```ts
api.registerElement(element, 'group-1', {
  nextByDirection: { // This will set the next element manually
    'down': 'element-0-1', // The next element when the user press the down arrow key
    'right': { id: 'group-1', kind: 'group' }, // The next group when the user press the right arrow key
    'up': null, // If press up, no elements will be focused
    'left': undefined // undefined will keep the default behavior
  },
  onFocus: ({ current, prev, direction }) => console.log(`focused ${current.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
  onBlur: ({ current, next, direction }) => console.log(`blurred ${current.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
})
```
- Add id to elements, thinking about a future react native adapter on the core
- Group elements now is a set of ids that references elements on main Map in the state.