### PR TITLE
Add byOrder group configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![install size](https://packagephobia.com/badge?p=@arrow-navigation/core)](https://packagephobia.com/result?p=@arrow-navigation/core)
 
-Light (~10kb) and zero-dependency module to navigate through elements using the arrow keys written in Typescript.
+Light (~13kb) and zero-dependency module to navigate through elements using the arrow keys written in Typescript.
 
 ## Installation
 
@@ -15,6 +15,10 @@ npm install --save @arrow-navigation/core
 
 yarn add @arrow-navigation/core
 ```
+
+## What is new?
+
+- **v1.2.8**: Add the `byOrder` option on groups. Now you can navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid'. You can also set the number of columns to navigate when the byOrder is 'grid' using the `cols` option.
 
 ## Usage
 
@@ -100,6 +104,8 @@ api.registerGroup(container, {
     'up': null, // If press up, no groups will be focused
     'left': undefined // undefined will keep the default behavior
   },
+  byOrder: 'horizontal', // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid'. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
+  cols: 2, // The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 }
   saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
   viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true
   threshold: 2, // The threshold in pixels to consider an element eligible to be focused. The default value is 0
@@ -141,6 +147,7 @@ api.registerElement(element, 'group-1', {
     'up': null, // If press up, no elements will be focused
     'left': undefined // undefined will keep the default behavior
   },
+  order: 0, // The order of the element. No default value. This is needed when the group is setted to navigate byOrder. If no setted, byOrder will be ignored.
   onFocus: ({ current, prev, direction }) => console.log(`focused ${current.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
   onBlur: ({ current, next, direction }) => console.log(`blurred ${current.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrow-navigation/core",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Zero-dependency library to navigate through UI elements using the keyboard arrow keys built with Typescript",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/handlers/registerElementHandler.test.ts
+++ b/src/handlers/registerElementHandler.test.ts
@@ -105,4 +105,34 @@ describe('registerElementHandler', () => {
 
     expect(state.groups.get('group-10')?.el).toBe(group)
   })
+
+  it('should register an element with order', () => {
+    state.groupsConfig.set('group-6', {
+      id: 'group-6',
+      el: state.groups.get('group-6')?.el as HTMLElement,
+      byOrder: 'horizontal'
+    })
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
+
+    const element = document.createElement('button')
+    registerElement(element, 'group-6', { order: 0 })
+
+    expect(state.elements.has('group-6-0')).toBe(true)
+    expect(state.elements.get(element.id)?.el).toBe(element)
+    expect(state.elements.get(element.id)?.el.id).toBe('group-6-0')
+    expect(state.elements.get(element.id)?.id).toBe('group-6-0')
+    expect(state.groups.get('group-6')?.elements.has('group-6-0')).toBe(true)
+  })
+
+  it('should not register an element with order if the group is byOrder but the element doesnt have order', () => {
+    state.groupsConfig.set('group-6', {
+      id: 'group-6',
+      el: state.groups.get('group-6')?.el as HTMLElement,
+      byOrder: 'horizontal'
+    })
+    const registerElement = registerElementHandler(state, onChangeElement, emitter.emit)
+
+    const element = document.createElement('button')
+    expect(() => registerElement(element, 'group-6')).toThrowError(ERROR_MESSAGES.ELEMENT_ID_REQUIRED)
+  })
 })

--- a/src/handlers/utils/findNextByDirection.test.ts
+++ b/src/handlers/utils/findNextByDirection.test.ts
@@ -186,4 +186,61 @@ describe('findNextByDirection', () => {
 
     expect(next).toBe(undefined)
   })
+
+  it('should return the next element in order with byOrder is setted on group', () => {
+    state.groupsConfig.set('group-0', {
+      ...state.groupsConfig.get('group-0') as FocusableGroupConfig,
+      byOrder: 'vertical'
+    })
+    let count = 0
+    state.groups.get('group-0')?.elements.forEach(id => {
+      state.elements.set(`group-0-${count}`, {
+        ...state.elements.get(id) as FocusableElement,
+        order: count
+      })
+      count += 1
+    })
+    const next = findNextByDirection({
+      direction: 'down',
+      state,
+      fromElement: state.elements.get('group-0-0') as FocusableElement
+    })
+    expect(next).toBe(state.elements.get('group-0-1'))
+  })
+
+  it('should return null if the next element id is null', () => {
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: {
+          id: null,
+          kind: 'element'
+        }
+      }
+    })
+    const next = findNextByDirection({
+      direction: 'right',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+    expect(next).toBe(null)
+  })
+
+  it('should return undefined if the next element id is undefined', () => {
+    state.elements.set('element-0-0', {
+      ...state.elements.get('element-0-0') as FocusableElement,
+      nextByDirection: {
+        right: {
+          id: undefined,
+          kind: 'element'
+        }
+      }
+    })
+    const next = findNextByDirection({
+      direction: 'right',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+    expect(next).toBe(undefined)
+  })
 })

--- a/src/handlers/utils/findNextElement.test.ts
+++ b/src/handlers/utils/findNextElement.test.ts
@@ -1,6 +1,6 @@
 import getCurrentElement from '@/utils/getCurrentElement'
 import getViewNavigationStateMock from '@/__mocks__/viewNavigationState.mock'
-import type { ArrowNavigationState, FocusableElement } from '@/types'
+import type { ArrowNavigationState, FocusableElement, FocusableGroupConfig } from '@/types'
 import findNextElement from './findNextElement'
 
 describe('findNextElement', () => {
@@ -96,5 +96,23 @@ describe('findNextElement', () => {
     })
 
     expect(nextElement).toBe(null)
+  })
+
+  it('should return the next element in order with byOrder is setted on group', () => {
+    state.groupsConfig.set('group-0', {
+      ...state.groupsConfig.get('group-0') as FocusableGroupConfig,
+      byOrder: 'vertical'
+    })
+    let count = 0
+    state.groups.get('group-0')?.elements.forEach(id => {
+      (state.elements.get(id) as FocusableElement).order = count
+      count += 1
+    })
+    const next = findNextElement({
+      direction: 'down',
+      state,
+      fromElement: state.elements.get('element-0-0') as FocusableElement
+    })
+    expect(next).toBe(state.elements.get('element-0-1'))
   })
 })

--- a/src/handlers/utils/findNextElement.ts
+++ b/src/handlers/utils/findNextElement.ts
@@ -1,4 +1,5 @@
 import type { ArrowNavigationState, FocusableElement, FocusableGroup } from '@/types'
+import getCurrentElement from '@/utils/getCurrentElement'
 import findClosestElementInGroup from './findClosestElementInGroup'
 import findNextElementByDirection from './findNextElementByDirection'
 import findNextGroup from './findNextGroup'
@@ -17,13 +18,14 @@ export default function findNextElement ({
   state,
   inGroup = false
 }: Props): FocusableElement | null {
-  const currentElement = state.elements.get(state.currentElement as string) as FocusableElement
-  const selectedElement = fromElement || currentElement
+  const selectedElement = fromElement || getCurrentElement(state) as FocusableElement
   const fromGroup = state.groups.get(selectedElement?.group) as FocusableGroup
   const fromGroupConfig = state.groupsConfig.get(selectedElement?.group)
   let nextElement: FocusableElement | null | undefined
 
-  if (selectedElement?.nextByDirection) {
+  if (selectedElement?.nextByDirection
+    || (fromGroupConfig?.byOrder || selectedElement?.order !== undefined)
+  ) {
     nextElement = findNextByDirection({
       direction,
       fromElement: selectedElement,

--- a/src/handlers/utils/getNextByOrder/getNextByOrderGrid.test.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderGrid.test.ts
@@ -1,0 +1,103 @@
+import getNextByOrderGrid from './getNextByOrderGrid'
+
+describe('getNextByOrderGrid', () => {
+  it('should return the next element by order in the grid', () => {
+    const props = {
+      group: 'group-1',
+      order: 0,
+      groupSize: 10,
+      nextGroupByDirection: {
+        right: 'group-2',
+        down: 'group-3',
+        left: null,
+        up: null
+      },
+      groupCols: 2,
+      viewportWidth: 1000
+    }
+    const nextByDirection1 = getNextByOrderGrid({
+      ...props,
+      order: 0
+    })
+    expect(nextByDirection1).toEqual({
+      left: { id: null, kind: 'group' },
+      right: { id: 'group-1-1', kind: 'element' },
+      up: { id: null, kind: 'group' },
+      down: { id: 'group-1-2', kind: 'element' }
+    })
+
+    const nextByDirection2 = getNextByOrderGrid({
+      ...props,
+      order: 1
+    })
+    expect(nextByDirection2).toEqual({
+      left: { id: 'group-1-0', kind: 'element' },
+      right: { id: 'group-2', kind: 'group' },
+      up: { id: null, kind: 'group' },
+      down: { id: 'group-1-3', kind: 'element' }
+    })
+
+    const nextByDirection3 = getNextByOrderGrid({
+      ...props,
+      order: 9
+    })
+    expect(nextByDirection3).toEqual({
+      left: { id: 'group-1-8', kind: 'element' },
+      right: { id: 'group-2', kind: 'group' },
+      up: { id: 'group-1-7', kind: 'element' },
+      down: { id: 'group-3', kind: 'group' }
+    })
+
+    const nextByDirection4 = getNextByOrderGrid({
+      ...props,
+      order: 8
+    })
+    expect(nextByDirection4).toEqual({
+      left: { id: null, kind: 'group' },
+      right: { id: 'group-1-9', kind: 'element' },
+      up: { id: 'group-1-6', kind: 'element' },
+      down: { id: 'group-3', kind: 'group' }
+    })
+
+    const nextByDirection5 = getNextByOrderGrid({
+      ...props,
+      nextGroupByDirection: {
+        right: undefined,
+        down: undefined,
+        left: undefined,
+        up: undefined
+      },
+      order: 9
+    })
+    expect(nextByDirection5).toEqual({
+      left: { id: 'group-1-8', kind: 'element' },
+      right: { id: undefined, kind: 'group' },
+      up: { id: 'group-1-7', kind: 'element' },
+      down: { id: undefined, kind: 'group' }
+    })
+
+    const nextByDirection6 = getNextByOrderGrid({
+      ...props,
+      order: 0,
+      groupCols: { 0: 1, 600: 2, 900: 3 },
+      viewportWidth: 500
+    })
+    expect(nextByDirection6.right).toEqual({ id: 'group-2', kind: 'group' })
+
+    const nextByDirection7 = getNextByOrderGrid({
+      ...props,
+      order: 0,
+      groupCols: 0
+    })
+    expect(nextByDirection7.down).toEqual({ id: 'group-1-1', kind: 'element' })
+    expect(nextByDirection7.right).toEqual({ id: 'group-2', kind: 'group' })
+
+    const nextByDirection8 = getNextByOrderGrid({
+      ...props,
+      order: 0,
+      groupCols: undefined
+    })
+    expect(nextByDirection8.down).toEqual({ id: 'group-1-1', kind: 'element' })
+    expect(nextByDirection8.right).toEqual({ id: 'group-2', kind: 'group' })
+  })
+})

--- a/src/handlers/utils/getNextByOrder/getNextByOrderGrid.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderGrid.ts
@@ -1,0 +1,45 @@
+import { ElementByDirection, FocusableByDirection, FocusableWithKind } from '@/types'
+import getColsByWidth from './utils/getColsByWidth'
+
+interface Props {
+  group: string
+  order: number
+  groupSize: number
+  groupCols: number | Record<number, number> | undefined
+  nextGroupByDirection: ElementByDirection
+  viewportWidth: number
+}
+
+export default function getNextByOrderGrid ({
+  group,
+  order,
+  groupSize,
+  nextGroupByDirection,
+  groupCols,
+  viewportWidth
+}: Props): FocusableByDirection {
+  const size = groupSize
+  const breakpoints = typeof groupCols === 'number'
+    ? { 0: groupCols }
+    : (groupCols || { 0: 1 })
+  const cols = getColsByWidth(breakpoints, viewportWidth) || 1
+  const totalRows = Math.ceil(size / cols)
+
+  const row = Math.floor(order / cols)
+  const col = order % cols
+
+  return {
+    left: (col <= 0
+      ? { id: nextGroupByDirection.left, kind: 'group' }
+      : { id: `${group}-${order - 1}`, kind: 'element' }) as FocusableWithKind,
+    right: (col >= cols - 1
+      ? { id: nextGroupByDirection.right, kind: 'group' }
+      : { id: `${group}-${order + 1}`, kind: 'element' }) as FocusableWithKind,
+    up: (row <= 0
+      ? { id: nextGroupByDirection.up, kind: 'group' }
+      : { id: `${group}-${order - cols}`, kind: 'element' }) as FocusableWithKind,
+    down: (row >= totalRows - 1
+      ? { id: nextGroupByDirection.down, kind: 'group' }
+      : { id: `${group}-${order + cols}`, kind: 'element' }) as FocusableWithKind
+  }
+}

--- a/src/handlers/utils/getNextByOrder/getNextByOrderHorizontal.test.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderHorizontal.test.ts
@@ -1,0 +1,46 @@
+import getNextByOrderHorizontal from './getNextByOrderHorizontal'
+
+describe('getNextByOrderHorizontal', () => {
+  const props = {
+    group: 'group-1',
+    order: 0,
+    groupSize: 5,
+    nextGroupByDirection: {
+      right: 'group-2',
+      down: 'group-3',
+      left: null,
+      up: null
+    }
+  }
+  it('should return the next element by order in the horizontal group', () => {
+    const nextByDirection1 = getNextByOrderHorizontal(props)
+    expect(nextByDirection1).toEqual({
+      left: { id: null, kind: 'group' },
+      right: { id: 'group-1-1', kind: 'element' },
+      up: { id: null, kind: 'group' },
+      down: { id: 'group-3', kind: 'group' }
+    })
+
+    const nextByDirection2 = getNextByOrderHorizontal({
+      ...props,
+      order: 1
+    })
+    expect(nextByDirection2).toEqual({
+      left: { id: 'group-1-0', kind: 'element' },
+      right: { id: 'group-1-2', kind: 'element' },
+      up: { id: null, kind: 'group' },
+      down: { id: 'group-3', kind: 'group' }
+    })
+
+    const nextByDirection3 = getNextByOrderHorizontal({
+      ...props,
+      order: 5
+    })
+    expect(nextByDirection3).toEqual({
+      left: { id: 'group-1-4', kind: 'element' },
+      right: { id: 'group-2', kind: 'group' },
+      up: { id: null, kind: 'group' },
+      down: { id: 'group-3', kind: 'group' }
+    })
+  })
+})

--- a/src/handlers/utils/getNextByOrder/getNextByOrderHorizontal.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderHorizontal.ts
@@ -1,0 +1,28 @@
+import { ElementByDirection, FocusableByDirection, FocusableWithKind } from '@/types'
+
+interface Props {
+  group: string
+  order: number
+  groupSize: number
+  nextGroupByDirection: ElementByDirection
+}
+
+export default function getNextByOrderHorizontal ({
+  group,
+  order,
+  groupSize,
+  nextGroupByDirection
+}: Props): FocusableByDirection {
+  const size = groupSize
+
+  return {
+    left: (order <= 0
+      ? { id: nextGroupByDirection.left, kind: 'group' }
+      : { id: `${group}-${order - 1}`, kind: 'element' }) as FocusableWithKind,
+    right: (order >= size - 1
+      ? { id: nextGroupByDirection.right, kind: 'group' }
+      : { id: `${group}-${order + 1}`, kind: 'element' }) as FocusableWithKind,
+    up: { id: nextGroupByDirection.up, kind: 'group' },
+    down: { id: nextGroupByDirection.down, kind: 'group' }
+  }
+}

--- a/src/handlers/utils/getNextByOrder/getNextByOrderVertical.test.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderVertical.test.ts
@@ -1,0 +1,47 @@
+import getNextByOrderVertical from './getNextByOrderVertical'
+
+describe('getNextByOrderVertical', () => {
+  const props = {
+    group: 'group-1',
+    order: 0,
+    groupSize: 5,
+    nextGroupByDirection: {
+      right: 'group-2',
+      down: 'group-3',
+      left: null,
+      up: null
+    }
+  }
+
+  it('should return the next element by order in the vertical group', () => {
+    const nextByDirection1 = getNextByOrderVertical(props)
+    expect(nextByDirection1).toEqual({
+      up: { id: null, kind: 'group' },
+      down: { id: 'group-1-1', kind: 'element' },
+      left: { id: null, kind: 'group' },
+      right: { id: 'group-2', kind: 'group' }
+    })
+
+    const nextByDirection2 = getNextByOrderVertical({
+      ...props,
+      order: 1
+    })
+    expect(nextByDirection2).toEqual({
+      up: { id: 'group-1-0', kind: 'element' },
+      down: { id: 'group-1-2', kind: 'element' },
+      left: { id: null, kind: 'group' },
+      right: { id: 'group-2', kind: 'group' }
+    })
+
+    const nextByDirection3 = getNextByOrderVertical({
+      ...props,
+      order: 5
+    })
+    expect(nextByDirection3).toEqual({
+      up: { id: 'group-1-4', kind: 'element' },
+      down: { id: 'group-3', kind: 'group' },
+      left: { id: null, kind: 'group' },
+      right: { id: 'group-2', kind: 'group' }
+    })
+  })
+})

--- a/src/handlers/utils/getNextByOrder/getNextByOrderVertical.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderVertical.ts
@@ -1,0 +1,28 @@
+import { ElementByDirection, FocusableByDirection, FocusableWithKind } from '@/types'
+
+interface Props {
+  group: string
+  order: number
+  groupSize: number
+  nextGroupByDirection: ElementByDirection
+}
+
+export default function getNextByOrderVertical ({
+  group,
+  order,
+  groupSize,
+  nextGroupByDirection
+}: Props): FocusableByDirection {
+  const size = groupSize
+
+  return {
+    up: (order <= 0
+      ? { id: nextGroupByDirection.up, kind: 'group' }
+      : { id: `${group}-${order - 1}`, kind: 'element' }) as FocusableWithKind,
+    down: (order >= size - 1
+      ? { id: nextGroupByDirection.down, kind: 'group' }
+      : { id: `${group}-${order + 1}`, kind: 'element' }) as FocusableWithKind,
+    left: { id: nextGroupByDirection.left, kind: 'group' },
+    right: { id: nextGroupByDirection.right, kind: 'group' }
+  }
+}

--- a/src/handlers/utils/getNextByOrder/index.ts
+++ b/src/handlers/utils/getNextByOrder/index.ts
@@ -1,0 +1,35 @@
+import { ElementByDirection, FocusableGroupConfig } from '@/types'
+import getNextByOrderGrid from './getNextByOrderGrid'
+import getNextByOrderHorizontal from './getNextByOrderHorizontal'
+import getNextByOrderVertical from './getNextByOrderVertical'
+
+const nextByOrderFuncs = {
+  grid: getNextByOrderGrid,
+  horizontal: getNextByOrderHorizontal,
+  vertical: getNextByOrderVertical
+}
+
+interface Props {
+  group: string
+  order: number
+  groupSize: number
+  groupCols?: number | Record<number, number>
+  nextGroupByDirection?: ElementByDirection
+}
+
+export default function getNextByOrder (
+  byOrder: FocusableGroupConfig['byOrder'],
+  props: Props
+) {
+  const finalProps: Required<Props> & {
+    viewportWidth: number
+  } = {
+    group: props.group,
+    order: props.order || 0,
+    groupSize: props.groupSize,
+    groupCols: props.groupCols || 1,
+    nextGroupByDirection: props.nextGroupByDirection || {},
+    viewportWidth: window.innerWidth
+  }
+  return nextByOrderFuncs[byOrder || 'horizontal'](finalProps)
+}

--- a/src/handlers/utils/getNextByOrder/utils/getColsByWidth.test.ts
+++ b/src/handlers/utils/getNextByOrder/utils/getColsByWidth.test.ts
@@ -1,0 +1,16 @@
+import getColsByWidth from './getColsByWidth'
+
+describe('getColsByWidth', () => {
+  it('should return the number of columns by the width', () => {
+    const breakpoints = {
+      0: 1,
+      768: 2,
+      1024: 3
+    }
+    expect(getColsByWidth(breakpoints, 0)).toBe(1)
+    expect(getColsByWidth(breakpoints, 767)).toBe(1)
+    expect(getColsByWidth(breakpoints, 768)).toBe(2)
+    expect(getColsByWidth(breakpoints, 1023)).toBe(2)
+    expect(getColsByWidth(breakpoints, 1024)).toBe(3)
+  })
+})

--- a/src/handlers/utils/getNextByOrder/utils/getColsByWidth.ts
+++ b/src/handlers/utils/getNextByOrder/utils/getColsByWidth.ts
@@ -1,0 +1,8 @@
+export default function getColsByWidth (
+  breakpoints: Record<number, number>,
+  screenWidth: number
+) {
+  return Object.entries(breakpoints).reduce((acc, [breakpoint, columns]) => (
+    screenWidth >= parseInt(breakpoint, 10) ? columns : acc
+  ), 0)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type FocusType = 'first' | 'closest' | 'manual'
 export type Point = { x: number, y: number }
 
 export type FocusableWithKind = {
-  id: string
+  id: string | null | undefined
   kind: 'group' | 'element'
 }
 
@@ -44,6 +44,11 @@ export type FocusableElement = Focusable & {
    * Use nextByDirection instead. This property will be removed in the next major version.
    */
   nextElementByDirection?: ElementByDirection
+  /**
+   * If group is setted byOrder, the order will be used to find the next element.
+   * nextByDirection will be overrided by this property.
+   */
+  order?: number
   nextByDirection?: FocusableByDirection
   onFocus?: (result: FocusEventResult<FocusableElement>) => void
   onBlur?: (result: BlurEventResult<FocusableElement>) => void
@@ -59,6 +64,8 @@ export type FocusableGroupConfig = Focusable & {
   firstElement?: string
   lastElement?: string
   nextGroupByDirection?: ElementByDirection
+  byOrder?: 'horizontal' | 'vertical' | 'grid'
+  cols?: number | Record<number, number>
   saveLast?: boolean
   viewportSafe?: boolean
   threshold?: number


### PR DESCRIPTION
Add the `byOrder` option on groups. Now you can navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid'. You can also set the number of columns to navigate when the byOrder is 'grid' using the `cols` option.

Take care with this option, because this will change the id of the elements, for example, for `group-0`, the element in order 1 will be `group-0-1`. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.

```typescript
const container = document.createElement('div')

// Is important to keep a unique id for each group and his elements
container.id = 'group-0'

api.registerGroup(container, {
  firstElement: 'element-0-0', // The first element to be focused when the focus enter the group
  nextGroupByDirection: {
    'down': 'group-1', // The next group when the user press the down arrow key
    'up': null, // If press up, no groups will be focused
    'left': undefined // undefined will keep the default behavior
  },
  byOrder: 'horizontal', // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid'. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
  cols: 2, // The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 }
  saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
  viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true
  threshold: 2, // The threshold in pixels to consider an element eligible to be focused. The default value is 0
  onFocus: ({ current, prev, direction }) => { console.log(`focused ${current.id}`) }, // Callback when the group is focused. The prev group is the group that was focused before the current group.
  onBlur: ({ current, next, direction }) => { console.log(`blurred ${current.id}`) }, // Callback when the group is blurred. The next group is the group that will be focused when the focus leave the current group.
  keepFocus: true // If true, the focus will not leave the group when the user press the arrow keys. The default value is false. This option is usefull for modals or other elements that need to keep the focus inside.
})
```

```typescript
const api = getArrowNavigation()

const element = document.createElement('button')

// Is important to keep a unique id for each element
element.id = 'element-0-0'

api.registerElement(element, 'group-1', {
  nextByDirection: { // This will set the next element manually
    'down': 'element-0-1', // The next element when the user press the down arrow key
    'right': { id: 'group-1', kind: 'group' }, // The next group when the user press the right arrow key
    'up': null, // If press up, no elements will be focused
    'left': undefined // undefined will keep the default behavior
  },
  order: 0, // The order of the element. No default value. This is needed when the group is setted to navigate byOrder. If no setted, byOrder will be ignored.
  onFocus: ({ current, prev, direction }) => console.log(`focused ${current.id}`), // Callback when the element is focused. The prev element is the element that was focused before the current element.
  onBlur: ({ current, next, direction }) => console.log(`blurred ${current.id}`) // Callback when the element is blurred. The next element is the element that will be focused when the focus leave the current element.
})
```