### PR TITLE
Fix byOrder grid cols and add utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ api.registerGroup(container, {
     'up': null, // If press up, no groups will be focused
     'left': undefined // undefined will keep the default behavior
   },
-  byOrder: ArrowNavigationOrder.HORIZONTAL, // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
+  byOrder: ArrowNavigationOrder.HORIZONTAL, // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementIdByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
   cols: 2, // The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 }
   saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
   viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ api.registerGroup(container, {
     'up': null, // If press up, no groups will be focused
     'left': undefined // undefined will keep the default behavior
   },
-  byOrder: 'horizontal', // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid'. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
+  byOrder: ArrowNavigationOrder.HORIZONTAL, // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
   cols: 2, // The number of columns to navigate when the byOrder is 'grid'. The default value is 1 and you can set a object with the number of columns for each breakpoint. For example: { 0: 1, 768: 2, 1024: 3 }
   saveLast: true, // Save the last focused element when the focus leave the group and use it when the focus enter again
   viewportSafe: true, // If true, the next element will be the first element that is visible in the viewport. The default value is true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arrow-navigation/core",
-  "version": "1.2.10",
+  "version": "1.2.11",
   "description": "Zero-dependency library to navigate through UI elements using the keyboard arrow keys built with Typescript",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",

--- a/src/config/order.test.ts
+++ b/src/config/order.test.ts
@@ -1,0 +1,12 @@
+import ORDER from './order'
+
+describe('ORDER', () => {
+  // This test is for coverage only
+  it('should be an object with the correct keys', () => {
+    expect(ORDER).toEqual({
+      HORIZONTAL: 'horizontal',
+      VERTICAL: 'vertical',
+      GRID: 'grid'
+    })
+  })
+})

--- a/src/config/order.ts
+++ b/src/config/order.ts
@@ -1,0 +1,9 @@
+import { ORDER as ORDER_TYPE } from '@/types'
+
+const ORDER: ORDER_TYPE = {
+  HORIZONTAL: 'horizontal',
+  VERTICAL: 'vertical',
+  GRID: 'grid'
+}
+
+export default ORDER

--- a/src/handlers/registerElementHandler.ts
+++ b/src/handlers/registerElementHandler.ts
@@ -1,6 +1,7 @@
 import EVENTS from '@/config/events'
 import type { ArrowNavigationState, FocusableElement, FocusableElementOptions } from '@/types'
 import type { EventEmitter } from '@/utils/createEventEmitter'
+import getElementIdByOrder from '@/utils/getElementIdByOrder'
 import isElementDisabled from './utils/isElementDisabled'
 import isFocusableElement from './utils/isFocusableElement'
 
@@ -45,7 +46,7 @@ export default function registerElementHandler (
     }
 
     const id = isByOrder
-      ? `${group}-${options.order}`
+      ? getElementIdByOrder(group, options.order || 0)
       : element.id
 
     element.setAttribute('id', id)

--- a/src/handlers/utils/findNextByDirection.ts
+++ b/src/handlers/utils/findNextByDirection.ts
@@ -28,6 +28,7 @@ export default function findNextByDirection ({
       group: selectedElement.group,
       order: selectedElement.order || 0,
       groupSize: fromGroupElementsSize,
+      groupCols: fromGroupConfig.cols,
       nextGroupByDirection: fromGroupConfig.nextGroupByDirection
     })
   }

--- a/src/handlers/utils/getNextByOrder/getNextByOrderGrid.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderGrid.ts
@@ -1,4 +1,5 @@
 import { ElementByDirection, FocusableByDirection, FocusableWithKind } from '@/types'
+import getElementIdByOrder from '@/utils/getElementIdByOrder'
 import getColsByWidth from './utils/getColsByWidth'
 
 interface Props {
@@ -31,15 +32,15 @@ export default function getNextByOrderGrid ({
   return {
     left: (col <= 0
       ? { id: nextGroupByDirection.left, kind: 'group' }
-      : { id: `${group}-${order - 1}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order - 1), kind: 'element' }) as FocusableWithKind,
     right: (col >= cols - 1
       ? { id: nextGroupByDirection.right, kind: 'group' }
-      : { id: `${group}-${order + 1}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order + 1), kind: 'element' }) as FocusableWithKind,
     up: (row <= 0
       ? { id: nextGroupByDirection.up, kind: 'group' }
-      : { id: `${group}-${order - cols}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order - cols), kind: 'element' }) as FocusableWithKind,
     down: (row >= totalRows - 1
       ? { id: nextGroupByDirection.down, kind: 'group' }
-      : { id: `${group}-${order + cols}`, kind: 'element' }) as FocusableWithKind
+      : { id: getElementIdByOrder(group, order + cols), kind: 'element' }) as FocusableWithKind
   }
 }

--- a/src/handlers/utils/getNextByOrder/getNextByOrderHorizontal.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderHorizontal.ts
@@ -1,4 +1,5 @@
 import { ElementByDirection, FocusableByDirection, FocusableWithKind } from '@/types'
+import getElementIdByOrder from '@/utils/getElementIdByOrder'
 
 interface Props {
   group: string
@@ -18,10 +19,10 @@ export default function getNextByOrderHorizontal ({
   return {
     left: (order <= 0
       ? { id: nextGroupByDirection.left, kind: 'group' }
-      : { id: `${group}-${order - 1}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order - 1), kind: 'element' }) as FocusableWithKind,
     right: (order >= size - 1
       ? { id: nextGroupByDirection.right, kind: 'group' }
-      : { id: `${group}-${order + 1}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order + 1), kind: 'element' }) as FocusableWithKind,
     up: { id: nextGroupByDirection.up, kind: 'group' },
     down: { id: nextGroupByDirection.down, kind: 'group' }
   }

--- a/src/handlers/utils/getNextByOrder/getNextByOrderVertical.ts
+++ b/src/handlers/utils/getNextByOrder/getNextByOrderVertical.ts
@@ -1,4 +1,5 @@
 import { ElementByDirection, FocusableByDirection, FocusableWithKind } from '@/types'
+import getElementIdByOrder from '@/utils/getElementIdByOrder'
 
 interface Props {
   group: string
@@ -18,10 +19,10 @@ export default function getNextByOrderVertical ({
   return {
     up: (order <= 0
       ? { id: nextGroupByDirection.up, kind: 'group' }
-      : { id: `${group}-${order - 1}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order - 1), kind: 'element' }) as FocusableWithKind,
     down: (order >= size - 1
       ? { id: nextGroupByDirection.down, kind: 'group' }
-      : { id: `${group}-${order + 1}`, kind: 'element' }) as FocusableWithKind,
+      : { id: getElementIdByOrder(group, order + 1), kind: 'element' }) as FocusableWithKind,
     left: { id: nextGroupByDirection.left, kind: 'group' },
     right: { id: nextGroupByDirection.right, kind: 'group' }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,10 @@ export {
   getArrowNavigation
 } from './arrowNavigation'
 
+export { default as getElementIdByOrder } from './utils/getElementIdByOrder'
+
 export { default as ArrowNavigationEvents } from './config/events'
+export { default as ArrowNavigationOrder } from './config/order'
 
 export type {
   FocusableElement,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,12 @@ export type Direction = 'up' | 'down' | 'left' | 'right'
 
 export type FocusType = 'first' | 'closest' | 'manual'
 
+export type ORDER = {
+  HORIZONTAL: 'horizontal'
+  VERTICAL: 'vertical'
+  GRID: 'grid'
+}
+
 export type Point = { x: number, y: number }
 
 export type FocusableWithKind = {
@@ -64,7 +70,7 @@ export type FocusableGroupConfig = Focusable & {
   firstElement?: string
   lastElement?: string
   nextGroupByDirection?: ElementByDirection
-  byOrder?: 'horizontal' | 'vertical' | 'grid'
+  byOrder?: ORDER[keyof ORDER]
   cols?: number | Record<number, number>
   saveLast?: boolean
   viewportSafe?: boolean

--- a/src/utils/getElementByOrder.test.ts
+++ b/src/utils/getElementByOrder.test.ts
@@ -1,0 +1,7 @@
+import getElementIdByOrder from './getElementIdByOrder'
+
+describe('getElementIdByOrder', () => {
+  it('should return the element id', () => {
+    expect(getElementIdByOrder('group-0', 0)).toBe('group-0-0')
+  })
+})

--- a/src/utils/getElementIdByOrder.ts
+++ b/src/utils/getElementIdByOrder.ts
@@ -1,0 +1,3 @@
+export default function getElementIdByOrder (groupId: string, idx: number) {
+  return `${groupId}-${idx}`
+}


### PR DESCRIPTION
- Fix cols bug for grid calculation
- Add constants for byOrder options
```
byOrder: ArrowNavigationOrder.HORIZONTAL, // Navigate by order setted on elements. Can be 'horizontal', 'vertical' or 'grid', this enum comes with ArrowNavigationOrder constant object. Take care with this option, because this will change the id of the elements, for example, for group-0, the element in order 1 will be group-0-1. It includes a utility function getElementByOrder(groupId, order): string. Keep this in mind if you are using the id of the elements for firstElement or nextByDirection options.
```
- Expose utility function for `getElementIdByOrder(group, order)` for safe id conversion.